### PR TITLE
Lodash CVE-2018-3721

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir /app
 WORKDIR /app
 
 ADD ./package.json /app/
+ADD ./package-lock.json /app/
 RUN npm install
 ENV NODE_PATH /app/node_modules
 ENV PATH $PATH:/app/node_modules/.bin

--- a/package-lock.json
+++ b/package-lock.json
@@ -5512,7 +5512,6 @@
         "eventemitter3": "1.1.1",
         "faye-websocket": "0.11.1",
         "jsonparse": "1.3.1",
-        "lodash": "3.10.1",
         "object-assign": "4.1.1"
       }
     },
@@ -5765,9 +5764,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash.sortby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "json-rpc2": "^1.0.2",
     "json-schema-to-typescript": "^5.5.0",
     "json-stable-stringify": "^1.0.1",
+    "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
     "node-fetch": "^2.1.2",
     "pg": "^7.4.3",


### PR DESCRIPTION
[CVE-2018-3721](https://nvd.nist.gov/vuln/detail/CVE-2018-3721) describes a vulnerability in versions of Lodash prior to 4.17.5.  The `json-rpc2` package that we use has a dependency on version 3.x.x.

As of this writing, there are multiple pull requests against the json-rpc2 package to resolve this vulnerable Lodash dependency version, however no updates to this repository have been made since 2015-09-13.  The usages of Lodash methods in the json-rpc2 package have been reviewed and were not affected by the breaking changes in the Lodash version 4.x.x release.  To resolve the vulnerability in Engine, an explicit Lodash (^4.17.10) is being installed to override the vulnerable version.

Yarn was considered for managing the sub-dependency versions, however the [vulnerability scanning](https://help.github.com/articles/about-security-alerts-for-vulnerable-dependencies/) provided by Github only scans `package.json` and `package-lock.json`.  `yarn.lock` is [not supported](https://help.github.com/articles/listing-the-packages-that-a-repository-depends-on/) at this time.