### PR TITLE
Transaction hash and better event subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 [![CircleCI](https://circleci.com/gh/ShipChain/engine/tree/master.svg?style=svg)](https://circleci.com/gh/ShipChain/engine/tree/master)
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![code style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=svg)](https://github.com/prettier/prettier)
+[![Chat](https://img.shields.io/badge/gitter-ShipChain/lobby-green.svg)](https://gitter.im/ShipChain/Lobby)
 
 # ShipChain Engine Project
 An RPC server that exposes our Typescript abstraction layer on top of Web3 bindings for ShipChain's Ethereum smart contracts.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Once Docker is installed, you will need a Docker "network" named `portal`:
 docker network create portal
 ```
 
+You will also need to create a new directory tree `/data/shipchain/engine/postgresql` to persist your local database.
+
+Note:  Depending on OS settings, some users may encounter permission errors when running Engine.  This is commonly due to missing [Shared Drives](https://docs.docker.com/docker-for-windows/#shared-drives) on Windows or [File Sharing](https://docs.docker.com/docker-for-mac/#file-sharing) on Mac.  Be sure these are setup to allow access to the `/data` directory you created.
+
 ### Installing
 
 Clone the repository:

--- a/rpc/transaction.ts
+++ b/rpc/transaction.ts
@@ -39,11 +39,12 @@ export class RPCTransaction {
         }
 
         const signerWallet = await Wallet.getById(args.signerWallet);
-        const txSigned = await signerWallet.sign_tx(args.txUnsigned);
+        const [txSigned, txHash] = await signerWallet.sign_tx(args.txUnsigned);
 
         return {
             success: true,
             transaction: txSigned,
+            hash: txHash
         };
     }
 

--- a/src/__tests__/contracts.ts
+++ b/src/__tests__/contracts.ts
@@ -70,7 +70,7 @@ describe('ContractEntity', function() {
                 await token.build_transaction('transfer', [other.address, 100 * SHIP]),
             );
 
-            const signed_tx = await owner.sign_tx(txParams);
+            const [signed_tx, txHash] = await owner.sign_tx(txParams);
 
             const receipt = await network.send_tx(signed_tx);
 

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -223,10 +223,11 @@ export class EventSubscription extends BaseEntity {
     private static buildPoll(eventSubscription: EventSubscription, eventName: string) {
         async function pollMethod() {
             return new Promise((resolve, reject) => {
+                logger.debug(`Searching for Events fromBlock ${eventSubscription.lastBlock ? +eventSubscription.lastBlock + 1 : 0}`);
                 eventSubscription.contractDriver.getPastEvents(
                     eventName,
                     {
-                        fromBlock: eventSubscription.lastBlock ? eventSubscription.lastBlock + 1 : 0,
+                        fromBlock: eventSubscription.lastBlock ? +eventSubscription.lastBlock + 1 : 0,
                         toBlock: 'latest',
                     },
                     async (error, events) => {
@@ -234,6 +235,8 @@ export class EventSubscription extends BaseEntity {
                             logger.error(`Error retrieving Events: ${error}`);
                             reject(error);
                         }
+
+                        logger.debug(`Found ${events.length} Events`);
 
                         if (events.length) {
                             let highestBlock = EventSubscription.findHighestBlockInEvents(

--- a/src/entity/Wallet.ts
+++ b/src/entity/Wallet.ts
@@ -179,12 +179,14 @@ export class Wallet extends BaseEntity {
 
         tx.sign(this.__unlocked_key_buffer());
 
-        return tx;
+        const txHash = '0x' + tx.hash().toString('hex');
+
+        return [tx, txHash];
     }
 
     async sign_and_send_tx(network, txParams) {
         txParams = await this.add_tx_params(network, txParams);
-
-        return await network.send_tx(this.sign_tx(txParams));
+        let [txSigned, txHash] = this.sign_tx(txParams);
+        return await network.send_tx(txSigned);
     }
 }


### PR DESCRIPTION
When signing a transaction, the hash can be generated and returned from Engine.  This allows API consumers more immediate access to tracking the transaction progress as it is submitted.

Event Subscriptions encountered an occasional bug where incorrect blocks were being scanned for events.  This was due to the entity's "bigint" field being treated as a string in the `fromBlock` generation logic.