### PR TITLE
Metrics Reporting

### DIFF
--- a/MetricsReporter.ts
+++ b/MetricsReporter.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { InfluxDB, IPoint, IWriteOptions } from "influx";
+import { Logger, loggers } from "winston";
+
+// @ts-ignore
+const logger: Logger = loggers.get("engine");
+const INFLUXDB_URL = process.env.INFLUXDB_URL;
+
+export class MetricsReporter {
+    private static _instance: MetricsReporter;
+
+    private readonly influx: InfluxDB = null;
+
+    private constructor() {
+        if(INFLUXDB_URL) {
+            // Connect to a single host with a DSN:
+            this.influx = new InfluxDB(INFLUXDB_URL);
+        } else {
+            logger.info(`Metrics reporting is disabled`);
+        }
+    }
+
+    public static get Instance(): MetricsReporter {
+        return this._instance || (this._instance = new this());
+    }
+
+    public report(measurement: string, point: IPoint, options: IWriteOptions = undefined) {
+        this.reportMultiple(measurement, [point], options)
+    }
+
+    public reportMultiple(measurement: string, points: IPoint[], options: IWriteOptions = undefined) {
+        if(this.influx) {
+            this.influx.writeMeasurement(measurement, points, options)
+                .then(
+                    result => {
+                        logger.error(`Successfully reporting metrics ${result}`);
+                    },
+                    error => {
+                        logger.error(`Caught Error when reporting metrics ${error}`);
+                    })
+                .catch(error => {
+                    logger.error(`Caught Error when reporting metrics ${error}`);
+                });
+        }
+    }
+
+}

--- a/README.md
+++ b/README.md
@@ -112,6 +112,11 @@ If you want to also log messages to ElasticSearch, add the following variable po
  - `ELASTICSEARCH_LEVEL`
  	- Defaults to the value set in `LOGGING_LEVEL`
 
+##### Metrics
+Engine supports the reporting of application metrics to an InfluxDB instance. We use this internally in combination with
+Graphana to make a real-time dashboard of our application use. In order to use this, set:
+ - `INFLUXDB_URL` - With the format `http://{host}:{port}/{database}`
+
 ## Running the tests
 
 Testing is handled through the Docker containers as well and can be invoked via the `bin/docker_tests` script.  This is the recommended way to run the tests.

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -54,6 +54,7 @@ services:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY
       - ELASTICSEARCH_URL
+      - INFLUXDB_URL
 
 networks:
   portal:

--- a/package-lock.json
+++ b/package-lock.json
@@ -4512,6 +4512,11 @@
         "wrappy": "1.0.2"
       }
     },
+    "influx": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/influx/-/influx-5.0.7.tgz",
+      "integrity": "sha1-NeZfa/E8uqF2MQi1WWqAanJ6Upo="
+    },
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
@@ -5512,7 +5517,15 @@
         "eventemitter3": "1.1.1",
         "faye-websocket": "0.11.1",
         "jsonparse": "1.3.1",
+        "lodash": "3.10.1",
         "object-assign": "4.1.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+        }
       }
     },
     "json-schema": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "eth-crypto": "^1.2.3",
     "ethereumjs-tx": "^1.3.7",
     "get-stream": "^3.0.0",
+    "influx": "^5.0.7",
     "json-rpc2": "^1.0.2",
     "json-schema-to-typescript": "^5.5.0",
     "json-stable-stringify": "^1.0.1",
@@ -46,7 +47,7 @@
     "server": "ts-node rpc-server.ts",
     "ingest_primitives": "node ingestPrimitives.js",
     "start": "nodemon -e 'ts' -x 'ts-node' rpc-server.ts",
-    "clean": "rm -rf ./dist && find src -name '*.js* -rm'",
+    "clean": "rm -rf ./dist && find src -name '*.js' -name '*.js.map' ! -name 'testLoggingConfig.js' -delete",
     "prettier": "./node_modules/.bin/prettier --write 'src/**/*.ts' 'rpc/**/*.ts' ",
     "typeorm": "tsc && ./node_modules/.bin/typeorm"
   },

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -27,7 +27,7 @@ import { RPCTransaction } from "./rpc/transaction";
 import { RPCStorageCredentials } from "./rpc/storage_credentials";
 
 import { getRDSconfig } from "./rdsconfig";
-import { MetricsReporter } from "./MetricsReporter";
+import { MetricsReporter } from "./src/MetricsReporter";
 
 const typeorm = require("typeorm");
 const rpc = require("json-rpc2");
@@ -120,18 +120,7 @@ async function startRpcServer() {
 
     const metrics = MetricsReporter.Instance;
 
-    metrics.report("lucas_test",
-        {
-            tags: {
-                hostname: "lucasgram"
-            },
-            fields: {
-                aString: "String Value",
-                aNumber: 1337,
-            },
-            timestamp: Date.now()
-        }
-    );
+    metrics.methodCall("startRpcServer");
 
     logger.info(`RPC server listening on ${PORT}`);
     server.listen(PORT, "0.0.0.0");

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -37,6 +37,7 @@ const process = require("process");
 // We need to ignore the TSError here until this is released: https://github.com/winstonjs/winston/pull/1362
 // @ts-ignore
 const logger: Logger = loggers.get("engine");
+const metrics = MetricsReporter.Instance;
 const PORT = process.env.PORT || 2000;
 
 
@@ -118,9 +119,7 @@ async function startRpcServer() {
     await loadContractFixtures();
     await startEventSubscriptions();
 
-    const metrics = MetricsReporter.Instance;
-
-    metrics.methodCall("startRpcServer");
+    metrics.countAction("startRpcServer");
 
     logger.info(`RPC server listening on ${PORT}`);
     server.listen(PORT, "0.0.0.0");

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -27,6 +27,7 @@ import { RPCTransaction } from "./rpc/transaction";
 import { RPCStorageCredentials } from "./rpc/storage_credentials";
 
 import { getRDSconfig } from "./rdsconfig";
+import { MetricsReporter } from "./MetricsReporter";
 
 const typeorm = require("typeorm");
 const rpc = require("json-rpc2");
@@ -35,7 +36,7 @@ const process = require("process");
 
 // We need to ignore the TSError here until this is released: https://github.com/winstonjs/winston/pull/1362
 // @ts-ignore
-const logger: Logger = loggers.get('engine');
+const logger: Logger = loggers.get("engine");
 const PORT = process.env.PORT || 2000;
 
 
@@ -116,6 +117,21 @@ async function startRpcServer() {
 
     await loadContractFixtures();
     await startEventSubscriptions();
+
+    const metrics = MetricsReporter.Instance;
+
+    metrics.report("lucas_test",
+        {
+            tags: {
+                hostname: "lucasgram"
+            },
+            fields: {
+                aString: "String Value",
+                aNumber: 1337,
+            },
+            timestamp: Date.now()
+        }
+    );
 
     logger.info(`RPC server listening on ${PORT}`);
     server.listen(PORT, "0.0.0.0");

--- a/rpc/contracts.ts
+++ b/rpc/contracts.ts
@@ -72,9 +72,7 @@ export class LoadedContracts {
                 }
             }
             throw new Error(`Contract '${project}' has no latest version specified`);
-        }
-
-        else {
+        } else {
             if (!this.contracts[project].hasOwnProperty(version)) {
                 throw new Error(`Contract '${project}' version '${version}' not loaded`);
             }
@@ -132,11 +130,11 @@ async function registerPreviousLoadContracts(LOAD_CONTRACT: LoadContract) {
     const previousContracts: Contract[] = await Contract.find({
         projectId: currentContract.projectId,
         networkId: currentContract.networkId,
-        versionId: typeorm.Not(currentContract.versionId)
+        versionId: typeorm.Not(currentContract.versionId),
     });
 
-    for(let previousContract of previousContracts){
-        const previousVersion: Version = await Version.findOne({id: previousContract.versionId});
+    for (let previousContract of previousContracts) {
+        const previousVersion: Version = await Version.findOne({ id: previousContract.versionId });
 
         const oldLoadContract: LoadContract = new LoadContract(currentContract.network.title, previousVersion.title);
         await oldLoadContract.Ready;
@@ -145,5 +143,4 @@ async function registerPreviousLoadContracts(LOAD_CONTRACT: LoadContract) {
 
         loadedContracts.register(currentContract.project.title, oldLoadContract);
     }
-
 }

--- a/rpc/decorators.ts
+++ b/rpc/decorators.ts
@@ -16,7 +16,7 @@
 
 import { validateUuid } from './validators';
 import { MetricsReporter } from '../src/MetricsReporter';
-import { Logger, loggers } from "winston";
+import { Logger, loggers } from 'winston';
 
 const rpc = require('json-rpc2');
 
@@ -63,8 +63,11 @@ export function RPCMethod(options?: RPCMethodOptions) {
 
             // We cannot check this at compile time due to the class-decorator not being
             // fully applied yet while the methods are being defined within the class
-            if(!target.__isRpcClass) {
-                logger.error(`@RPCMethod '${propertyKey}' used outside of @RPCNamespace in '${target.name || target.constructor.name}'`);
+            if (!target.__isRpcClass) {
+                logger.error(
+                    `@RPCMethod '${propertyKey}' used outside of @RPCNamespace in '${target.name ||
+                        target.constructor.name}'`,
+                );
             }
 
             metrics.methodCall(target.__rpcNamespace + '.' + propertyKey);
@@ -76,7 +79,10 @@ export function RPCMethod(options?: RPCMethodOptions) {
             originalMethod
                 .apply(context, arguments)
                 .then(resolve => callback(null, resolve))
-                .catch(reject => callback(reject));
+                .catch(reject => {
+                    metrics.methodFail(target.__rpcNamespace + '.' + propertyKey);
+                    callback(reject);
+                });
         };
 
         // return edited descriptor as opposed to overwriting the descriptor

--- a/rpc/event.ts
+++ b/rpc/event.ts
@@ -15,11 +15,13 @@
  */
 
 import { EventSubscription } from '../src/entity/EventSubscription';
+import { MetricsReporter } from '../src/MetricsReporter';
 
 import { RPCMethod, RPCNamespace } from './decorators';
 import { LoadedContracts } from './contracts';
 
 const loadedContracts = LoadedContracts.Instance;
+const metrics = MetricsReporter.Instance;
 
 @RPCNamespace({ name: 'Event' })
 export class RPCEvent {
@@ -28,6 +30,13 @@ export class RPCEvent {
         const eventSubscription = await EventSubscription.getOrCreate(args);
 
         await eventSubscription.start(loadedContracts.get(eventSubscription.project).getContractEntity());
+
+        // This should be non-blocking
+        EventSubscription.getCount()
+            .then(count => {
+                metrics.entityTotal('EventSubscription', count);
+            })
+            .catch(err => {});
 
         return {
             success: true,

--- a/rpc/event.ts
+++ b/rpc/event.ts
@@ -16,11 +16,12 @@
 
 import { EventSubscription } from '../src/entity/EventSubscription';
 
-import { RPCMethod } from './decorators';
+import { RPCMethod, RPCNamespace } from './decorators';
 import { LoadedContracts } from './contracts';
 
 const loadedContracts = LoadedContracts.Instance;
 
+@RPCNamespace({ name: 'Event' })
 export class RPCEvent {
     @RPCMethod({ require: ['url', 'project'] })
     public static async Subscribe(args) {

--- a/rpc/load.ts
+++ b/rpc/load.ts
@@ -18,7 +18,7 @@ import { Wallet } from '../src/entity/Wallet';
 import { LoadVault } from '../src/shipchain/LoadVault';
 import { StorageCredential } from '../src/entity/StorageCredential';
 
-import { RPCMethod } from './decorators';
+import { RPCMethod, RPCNamespace } from './decorators';
 import { LoadedContracts } from './contracts';
 import { LoadContract } from '../src/shipchain/LoadContract';
 import { TokenContract } from '../src/shipchain/TokenContract';
@@ -26,6 +26,7 @@ import { validateShipmentArgs } from './validators';
 
 const loadedContracts = LoadedContracts.Instance;
 
+@RPCNamespace({ name: 'Load' })
 export class RPCLoad {
     @RPCMethod({
         require: ['storageCredentials', 'shipperWallet'],
@@ -40,7 +41,7 @@ export class RPCLoad {
         const vault = new LoadVault(storage);
         await vault.getOrCreateMetadata(shipperWallet);
 
-        if(args.carrierWallet) {
+        if (args.carrierWallet) {
             const carrierWallet = await Wallet.getById(args.carrierWallet);
             await vault.authorize(shipperWallet, 'owners', carrierWallet.public_key);
         }

--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -16,6 +16,9 @@
 
 import { RPCMethod, RPCNamespace } from './decorators';
 import { StorageCredential } from '../src/entity/StorageCredential';
+import { MetricsReporter } from '../src/MetricsReporter';
+
+const metrics = MetricsReporter.Instance;
 
 @RPCNamespace({ name: 'StorageCredentials' })
 export class RPCStorageCredentials {
@@ -24,6 +27,13 @@ export class RPCStorageCredentials {
         const credentials = StorageCredential.generate_entity(args);
 
         await credentials.save();
+
+        // This should be non-blocking
+        StorageCredential.getCount()
+            .then(count => {
+                metrics.entityTotal('StorageCredential', count);
+            })
+            .catch(err => {});
 
         return {
             success: true,

--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-import { RPCMethod } from './decorators';
+import { RPCMethod, RPCNamespace } from './decorators';
 import { StorageCredential } from '../src/entity/StorageCredential';
 
+@RPCNamespace({ name: 'StorageCredentials' })
 export class RPCStorageCredentials {
     @RPCMethod({ require: ['title', 'driver_type'] })
     public static async Create(args) {

--- a/rpc/transaction.ts
+++ b/rpc/transaction.ts
@@ -21,10 +21,11 @@ import { BaseContract } from '../src/contracts/BaseContract';
 import { TransmissionConfirmationCallback } from '../src/shipchain/TransmissionConfirmationCallback';
 
 import { LoadedContracts } from './contracts';
-import { RPCMethod } from './decorators';
+import { RPCMethod, RPCNamespace } from './decorators';
 
 const loadedContracts = LoadedContracts.Instance;
 
+@RPCNamespace({ name: 'Transaction' })
 export class RPCTransaction {
     @RPCMethod({
         require: ['signerWallet', 'txUnsigned'],
@@ -44,7 +45,7 @@ export class RPCTransaction {
         return {
             success: true,
             transaction: txSigned,
-            hash: txHash
+            hash: txHash,
         };
     }
 

--- a/rpc/wallet.ts
+++ b/rpc/wallet.ts
@@ -17,10 +17,11 @@
 import { Wallet } from '../src/entity/Wallet';
 import { BaseContract } from '../src/contracts/BaseContract';
 import { LoadedContracts } from './contracts';
-import { RPCMethod } from './decorators';
+import { RPCMethod, RPCNamespace } from './decorators';
 
 const loadedContracts = LoadedContracts.Instance;
 
+@RPCNamespace({ name: 'Wallet' })
 export class RPCWallet {
     @RPCMethod()
     public static async Create() {

--- a/rpc/wallet.ts
+++ b/rpc/wallet.ts
@@ -16,10 +16,12 @@
 
 import { Wallet } from '../src/entity/Wallet';
 import { BaseContract } from '../src/contracts/BaseContract';
+import { MetricsReporter } from '../src/MetricsReporter';
 import { LoadedContracts } from './contracts';
 import { RPCMethod, RPCNamespace } from './decorators';
 
 const loadedContracts = LoadedContracts.Instance;
+const metrics = MetricsReporter.Instance;
 
 @RPCNamespace({ name: 'Wallet' })
 export class RPCWallet {
@@ -27,6 +29,14 @@ export class RPCWallet {
     public static async Create() {
         const wallet = Wallet.generate_entity();
         await wallet.save();
+
+        // This should be non-blocking
+        Wallet.getCount()
+            .then(count => {
+                metrics.entityTotal('Wallet', count);
+            })
+            .catch(err => {});
+
         return {
             success: true,
             wallet: {
@@ -41,6 +51,14 @@ export class RPCWallet {
     public static async Import(args) {
         const wallet = await Wallet.import_entity(args.privateKey);
         await wallet.save();
+
+        // This should be non-blocking
+        Wallet.getCount()
+            .then(count => {
+                metrics.entityTotal('Wallet', count);
+            })
+            .catch(err => {});
+
         return {
             success: true,
             wallet: {

--- a/src/MetricsReporter.ts
+++ b/src/MetricsReporter.ts
@@ -59,25 +59,25 @@ export class MetricsReporter {
     }
 
     public methodCall(method: string) {
-        const point = MetricsReporter.buildPoint({method: method} );
+        const point = MetricsReporter.buildPoint({ method: method });
 
         this.report('engine.method_invocation', point);
     }
 
     public methodFail(method: string) {
-        const point = MetricsReporter.buildPoint({method: method} );
+        const point = MetricsReporter.buildPoint({ method: method });
 
         this.report('engine.method_failure', point);
     }
 
     public countAction(action: string, tags: any = {}) {
-        const point = MetricsReporter.buildPoint( Object.assign({action: action}, tags) );
+        const point = MetricsReporter.buildPoint(Object.assign({ action: action }, tags));
 
         this.report('engine.action_count', point);
     }
 
     public entityTotal(entity: string, count: number) {
-        const point = MetricsReporter.buildPoint({entity: entity}, {count: count} );
+        const point = MetricsReporter.buildPoint({ entity: entity }, { count: count });
 
         this.report('engine.entity_total', point);
     }

--- a/src/MetricsReporter.ts
+++ b/src/MetricsReporter.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { InfluxDB, IPoint, IWriteOptions } from "influx";
-import { Logger, loggers } from "winston";
+import { InfluxDB, IPoint, IWriteOptions } from 'influx';
+import { Logger, loggers } from 'winston';
 
 // @ts-ignore
-const logger: Logger = loggers.get("engine");
-const ENVIRONMENT = process.env.ENV || "LOCAL";
+const logger: Logger = loggers.get('engine');
+const ENVIRONMENT = process.env.ENV || 'LOCAL';
 const INFLUXDB_URL = process.env.INFLUXDB_URL;
 
 export class MetricsReporter {
@@ -28,9 +28,10 @@ export class MetricsReporter {
     private readonly influx: InfluxDB = null;
 
     private constructor() {
-        if(INFLUXDB_URL) {
+        if (INFLUXDB_URL) {
             // Connect to a single host with a DSN:
             this.influx = new InfluxDB(INFLUXDB_URL);
+            logger.info(`Metrics reporting is enabled`);
         } else {
             logger.info(`Metrics reporting is disabled`);
         }
@@ -41,38 +42,37 @@ export class MetricsReporter {
     }
 
     public methodCall(method: string) {
-
         const point = {
             tags: {
                 environment: ENVIRONMENT,
-                method: method
+                method: method,
             },
             fields: {
-                count: 1
+                count: 1,
             },
-            timestamp: new Date()
+            timestamp: new Date(),
         };
 
-        this.report('method_invocation', point)
+        this.report('engine.method_invocation', point);
     }
 
-
     protected report(measurement: string, point: IPoint, options: IWriteOptions = undefined) {
-        this.reportMultiple(measurement, [point], options)
+        this.reportMultiple(measurement, [point], options);
     }
 
     protected reportMultiple(measurement: string, points: IPoint[], options: IWriteOptions = undefined) {
-        if(this.influx) {
-            this.influx.writeMeasurement(measurement, points, options)
+        if (this.influx) {
+            this.influx
+                .writeMeasurement(measurement, points, options)
                 .then(
                     result => {},
                     error => {
                         logger.error(`Error when reporting metrics ${error}`);
-                    })
+                    },
+                )
                 .catch(error => {
                     logger.error(`Error when reporting metrics ${error}`);
                 });
         }
     }
-
 }

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -155,6 +155,18 @@ export class EventSubscription extends BaseEntity {
         return await repository.find();
     }
 
+    static async getCount() {
+        const DB = getConnection();
+        const repository = DB.getRepository(EventSubscription);
+
+        const count = await repository
+            .createQueryBuilder('eventSubscription')
+            .select('COUNT(eventSubscription.url) AS cnt')
+            .getRawMany();
+
+        return count[0]['cnt'];
+    }
+
     static async unsubscribe(url: string) {
         if (EventSubscription.activeSubscriptions[url]) {
             let eventSubscription = EventSubscription.activeSubscriptions[url];
@@ -223,7 +235,11 @@ export class EventSubscription extends BaseEntity {
     private static buildPoll(eventSubscription: EventSubscription, eventName: string) {
         async function pollMethod() {
             return new Promise((resolve, reject) => {
-                logger.debug(`Searching for Events fromBlock ${eventSubscription.lastBlock ? +eventSubscription.lastBlock + 1 : 0}`);
+                logger.debug(
+                    `Searching for Events fromBlock ${
+                        eventSubscription.lastBlock ? +eventSubscription.lastBlock + 1 : 0
+                    }`,
+                );
                 eventSubscription.contractDriver.getPastEvents(
                     eventName,
                     {

--- a/src/entity/StorageCredential.ts
+++ b/src/entity/StorageCredential.ts
@@ -66,6 +66,18 @@ export class StorageCredential extends BaseEntity {
             .getMany();
     }
 
+    static async getCount() {
+        const DB = getConnection();
+        const repository = DB.getRepository(StorageCredential);
+
+        const count = await repository
+            .createQueryBuilder('storageCredential')
+            .select('COUNT(storageCredential.id) AS cnt')
+            .getRawMany();
+
+        return count[0]['cnt'];
+    }
+
     static async getOptionsById(id: string) {
         const DB = getConnection();
         const repository = DB.getRepository(StorageCredential);

--- a/src/entity/Wallet.ts
+++ b/src/entity/Wallet.ts
@@ -77,6 +77,18 @@ export class Wallet extends BaseEntity {
             .getMany();
     }
 
+    static async getCount() {
+        const DB = getConnection();
+        const repository = DB.getRepository(Wallet);
+
+        const count = await repository
+            .createQueryBuilder('wallet')
+            .select('COUNT(wallet.id) AS cnt')
+            .getRawMany();
+
+        return count[0]['cnt'];
+    }
+
     static generate_identity() {
         return EthCrypto.createIdentity();
     }

--- a/src/storage/StorageDriver.ts
+++ b/src/storage/StorageDriver.ts
@@ -17,14 +17,17 @@
 import * as path from 'path';
 
 export abstract class StorageDriver {
+    protected readonly type: string = 'local';
+
     protected config;
     protected base_path = './'; // Default to root directory, overwrite with vault config if desired
 
-    protected constructor(config) {
+    protected constructor(config, type: string) {
         this.config = config;
         if (typeof config.base_path != undefined) {
             this.base_path = config.base_path;
         }
+        this.type = type;
     }
 
     protected getFullVaultPath(relativeFilePath: string) {

--- a/src/storage/drivers/LocalStorageDriver.ts
+++ b/src/storage/drivers/LocalStorageDriver.ts
@@ -15,6 +15,7 @@
  */
 
 import { DirectoryListing, DriverError, FileEntity, StorageDriver } from '../StorageDriver';
+import { MetricsReporter } from '../../MetricsReporter';
 
 const fs = require('fs');
 const util = require('util');
@@ -24,9 +25,12 @@ const _mkdirp = require('mkdirp');
 // Convert mkdirp into Promise version of same
 const mkdirp = util.promisify(_mkdirp);
 
+const metrics = MetricsReporter.Instance;
+
 export class LocalStorageDriver extends StorageDriver {
+
     constructor(config) {
-        super(config);
+        super(config, 'local');
     }
 
     private async _validateDirectoryPath(filePath: string): Promise<any> {
@@ -51,6 +55,7 @@ export class LocalStorageDriver extends StorageDriver {
     }
 
     async getFile(filePath: string, binary: boolean = false): Promise<any> {
+        metrics.countAction('storage_get_file', { driver_type: this.type });
         let encoding = binary ? null : 'utf8';
         return new Promise((resolve, reject) => {
             fs.readFile(this.getFullVaultPath(filePath), encoding, (err, data) => {
@@ -64,6 +69,7 @@ export class LocalStorageDriver extends StorageDriver {
     }
 
     async putFile(filePath: string, data: any, binary: boolean = false): Promise<any> {
+        metrics.countAction('storage_put_file', { driver_type: this.type });
         let encoding = binary ? null : 'utf8';
 
         if (!data) {
@@ -84,6 +90,7 @@ export class LocalStorageDriver extends StorageDriver {
     }
 
     async removeFile(filePath: string): Promise<any> {
+        metrics.countAction('storage_remove_file', { driver_type: this.type });
         return new Promise((resolve, reject) => {
             fs.unlink(this.getFullVaultPath(filePath), (err, data) => {
                 if (err) {
@@ -100,6 +107,7 @@ export class LocalStorageDriver extends StorageDriver {
     }
 
     async fileExists(filePath: string): Promise<any> {
+        metrics.countAction('storage_file_exists', { driver_type: this.type });
         return await this.checkIfFile(this.getFullVaultPath(filePath));
     }
 
@@ -156,6 +164,7 @@ export class LocalStorageDriver extends StorageDriver {
     }
 
     async listDirectory(vaultDirectory: string, recursive: boolean = false): Promise<any> {
+        metrics.countAction('storage_list_directory', { driver_type: this.type });
         let vaultSearchPath = vaultDirectory;
 
         if (vaultSearchPath) {

--- a/src/storage/drivers/S3StorageDriver.ts
+++ b/src/storage/drivers/S3StorageDriver.ts
@@ -15,10 +15,14 @@
  */
 
 import { DirectoryListing, DriverError, FileEntity, StorageDriver } from '../StorageDriver';
+import { MetricsReporter } from '../../MetricsReporter';
 import * as path from 'path';
 import S3 = require('aws-sdk/clients/s3');
 
+const metrics = MetricsReporter.Instance;
+
 export class S3StorageDriver extends StorageDriver {
+
     s3: S3;
     bucket: string;
 
@@ -26,7 +30,7 @@ export class S3StorageDriver extends StorageDriver {
     acl: S3.ObjectCannedACL;
 
     constructor(config) {
-        super(config);
+        super(config, 's3');
 
         let s3_options = { apiVersion: '2006-03-01' };
 
@@ -57,6 +61,7 @@ export class S3StorageDriver extends StorageDriver {
     }
 
     async getFile(filePath: string, binary: boolean = false): Promise<any> {
+        metrics.countAction('storage_get_file', { driver_type: this.type });
         let fullVaultPath = this.getFullVaultPath(filePath);
 
         return new Promise((resolve, reject) => {
@@ -81,6 +86,7 @@ export class S3StorageDriver extends StorageDriver {
     }
 
     async putFile(filePath: string, data: any, binary: boolean = false): Promise<any> {
+        metrics.countAction('storage_put_file', { driver_type: this.type });
         let fullVaultPath = this.getFullVaultPath(filePath);
 
         return new Promise((resolve, reject) => {
@@ -107,6 +113,7 @@ export class S3StorageDriver extends StorageDriver {
     }
 
     async removeFile(filePath: string): Promise<any> {
+        metrics.countAction('storage_remove_file', { driver_type: this.type });
         let fullVaultPath = this.getFullVaultPath(filePath);
 
         return new Promise((resolve, reject) => {
@@ -131,6 +138,7 @@ export class S3StorageDriver extends StorageDriver {
     }
 
     async fileExists(filePath: string): Promise<any> {
+        metrics.countAction('storage_file_exists', { driver_type: this.type });
         let fullVaultPath = this.getFullVaultPath(filePath);
 
         return new Promise((resolve, reject) => {
@@ -240,6 +248,7 @@ export class S3StorageDriver extends StorageDriver {
     }
 
     async listDirectory(vaultDirectory: string, recursive: boolean = false): Promise<any> {
+        metrics.countAction('storage_list_directory', { driver_type: this.type });
         let vaultSearchPath = vaultDirectory;
 
         if (vaultSearchPath) {

--- a/src/storage/drivers/SftpStorageDriver.ts
+++ b/src/storage/drivers/SftpStorageDriver.ts
@@ -15,14 +15,18 @@
  */
 
 import { DirectoryListing, DriverError, FileEntity, StorageDriver } from '../StorageDriver';
+import { MetricsReporter } from '../../MetricsReporter';
 import * as path from 'path';
 
 const getStream = require('get-stream');
 const SftpClient = require('ssh2-sftp-client');
 
+const metrics = MetricsReporter.Instance;
+
 export class SftpStorageDriver extends StorageDriver {
+
     constructor(config) {
-        super(config);
+        super(config, 'sftp');
     }
 
     private async _connect() {
@@ -41,6 +45,7 @@ export class SftpStorageDriver extends StorageDriver {
     }
 
     async getFile(filePath: string, binary: boolean = false): Promise<any> {
+        metrics.countAction('storage_get_file', { driver_type: this.type });
         let encodingSftp = binary ? null : 'utf8';
         let encodingStream = binary ? 'buffer' : 'utf8';
 
@@ -61,6 +66,7 @@ export class SftpStorageDriver extends StorageDriver {
     }
 
     async putFile(filePath: string, data: any, binary: boolean = false): Promise<any> {
+        metrics.countAction('storage_put_file', { driver_type: this.type });
         let encoding = binary ? null : 'utf8';
 
         if (!data) {
@@ -86,6 +92,7 @@ export class SftpStorageDriver extends StorageDriver {
     }
 
     async removeFile(filePath: string): Promise<any> {
+        metrics.countAction('storage_remove_file', { driver_type: this.type });
         let sftp = await this._connect();
 
         let fullVaultPath = this.getFullVaultPath(filePath);
@@ -104,6 +111,7 @@ export class SftpStorageDriver extends StorageDriver {
     }
 
     async fileExists(filePath: string): Promise<any> {
+        metrics.countAction('storage_file_exists', { driver_type: this.type });
         let sftp = await this._connect();
 
         let parsedPath = this.parseFullVaultPath(filePath);
@@ -165,6 +173,7 @@ export class SftpStorageDriver extends StorageDriver {
     }
 
     async listDirectory(vaultDirectory: string, recursive: boolean = false): Promise<any> {
+        metrics.countAction('storage_list_directory', { driver_type: this.type });
         let sftp = await this._connect();
 
         let vaultSearchPath = vaultDirectory;


### PR DESCRIPTION
Engine needs to support reporting application metrics to an InfluxDB instance. This provides the ability to track and analyze usage data to find the most used methods, alert when exceeding error thresholds, and identify potential areas for enhancing performance.  [Grafana](https://grafana.com/grafana) is a useful tool for building charts and graphs for displaying this information.

To enable metric reporting to InfluxDB, set the following environment variable:
 - `INFLUXDB_URL` - With the format `http://{host}:{port}/{database}`