### PR TITLE
Use public ETH node address

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN mkdir -p /contracts/contracts/LOAD/1.0/
 RUN mkdir -p /contracts/contracts/LOAD/1.0.2/
 RUN mkdir -p /contracts/contracts/ShipToken/1.0/
 WORKDIR /contracts
-RUN wget -O index.json https://s3.amazonaws.com/shipchain-contracts/index.json?versionId=null
+RUN wget -O index.json https://s3.amazonaws.com/shipchain-contracts/index.json
 RUN wget -O contracts/LOAD/1.0/compiled.bin https://s3.amazonaws.com/shipchain-contracts/contracts/LOAD/1.0/compiled.bin
 RUN wget -O contracts/LOAD/1.0.2/compiled.bin https://s3.amazonaws.com/shipchain-contracts/contracts/LOAD/1.0.2/compiled.bin
 RUN wget -O contracts/ShipToken/1.0/compiled.bin https://s3.amazonaws.com/shipchain-contracts/contracts/ShipToken/1.0/compiled.bin

--- a/src/entity/Contract.ts
+++ b/src/entity/Contract.ts
@@ -63,7 +63,7 @@ export class Project extends BaseEntity {
         const networks = {};
         for (let title of Object.keys(meta.networks)) {
             const nData = meta.networks[title];
-            networks[title] = await Network.getOrCreate(title, nData.internal_address, nData.description);
+            networks[title] = await Network.getOrCreate(title, nData.public_address, nData.description);
         }
 
         for (let title of Object.keys(meta.contracts)) {


### PR DESCRIPTION
Engine should be utilizing the `public_address` from the contract metadata instead of the `internal_address`.  This will allow broader use of Engine with the ShipChain smart contracts.