### PR TITLE
Prevent vault container overwrite

### DIFF
--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -586,7 +586,7 @@ export class ExternalListDailyContainer extends ExternalContainer {
 
     constructor(vault: Vault, name: string, meta?: any) {
         super(vault, name, meta);
-        this.encrypted_contents = meta ? meta.encrypted_contents : {};
+        this.encrypted_contents = null;
         this.raw_contents = {};
     }
 
@@ -613,12 +613,13 @@ export class ExternalListDailyContainer extends ExternalContainer {
         }
 
         let todaysProperty = ExternalListDailyContainer.getCurrentDayProperty();
+        this.desired_day = todaysProperty;
+
         const hash = utils.objectHash(blob);
+
         if (
             !this.raw_contents.hasOwnProperty(todaysProperty) &&
-            (this.encrypted_contents &&
-                this.encrypted_contents.hasOwnProperty(todaysProperty) &&
-                Object.keys(this.encrypted_contents[todaysProperty]).length)
+            this.meta[this.getExternalFilename()]
         ) {
             await this.decryptContents(author, todaysProperty);
         }


### PR DESCRIPTION
There is a bug in the Vault logic that can lead to losing data from unmodified containers during encryption.

When writing the modified the contents of only a single container in a vault where multiple containers exist, the `raw_contents` may not have been loaded prior to the encryption step. The solution is to use the existing container data or signature (depending on whether this is an Embedded or External Container) when writing the vault metadata.  This also has the benefit of making vault updates quicker as we're skipping an extraneous encryption cycle and potential I/O with an external Storage Driver.