### PR TITLE
Handle empty embedded list

### DIFF
--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -139,6 +139,92 @@ describe('Vaults', function() {
         expect(await vault.metadataFileExists()).toBe(false);
     });
 
+    it(`can properly create/read empty embedded file containers`, async () => {
+        let author = Wallet.generate_entity();
+        let vault = new Vault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+
+        vault.getOrCreateContainer(author, 'embedded_file', 'embedded_file');
+
+        await vault.writeMetadata(author);
+        expect(await vault.verify()).toBe(true);
+
+        const re_open = new Vault(storage_driver, vault.id);
+        await re_open.loadMetadata();
+        expect(await re_open.verify()).toBe(true);
+
+        const re_open_container = re_open.getOrCreateContainer(author, 'embedded_file', 'embedded_file');
+
+        try {
+            await re_open_container.decryptContents(author);
+            fail('Should not have decrypted empty embedded file');
+        } catch (_err) {
+            expect(_err).toEqual(new Error('Container contents empty'));
+        }
+    });
+
+    it(`can properly create/read empty embedded list containers`, async () => {
+        let author = Wallet.generate_entity();
+        let vault = new Vault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+
+        vault.getOrCreateContainer(author, 'embedded_list', 'embedded_list');
+
+        await vault.writeMetadata(author);
+        expect(await vault.verify()).toBe(true);
+
+        const re_open = new Vault(storage_driver, vault.id);
+        await re_open.loadMetadata();
+        expect(await re_open.verify()).toBe(true);
+
+        const re_open_container = re_open.getOrCreateContainer(author, 'embedded_list', 'embedded_list');
+
+        expect(await re_open_container.decryptContents(author)).toEqual([]);
+    });
+
+    it(`can properly create/read empty external file containers`, async () => {
+        let author = Wallet.generate_entity();
+        let vault = new Vault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+
+        vault.getOrCreateContainer(author, 'external_file', 'external_file');
+
+        await vault.writeMetadata(author);
+        expect(await vault.verify()).toBe(true);
+
+        const re_open = new Vault(storage_driver, vault.id);
+        await re_open.loadMetadata();
+        expect(await re_open.verify()).toBe(true);
+
+        const re_open_container = re_open.getOrCreateContainer(author, 'external_file', 'external_file');
+
+        try {
+            await re_open_container.decryptContents(author);
+            fail('Should not have decrypted empty external file');
+        } catch (_err) {
+            expect(_err).toEqual(new Error('Container contents empty'));
+        }
+    });
+
+    it(`can properly create/read empty external list containers`, async () => {
+        let author = Wallet.generate_entity();
+        let vault = new Vault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+
+        vault.getOrCreateContainer(author, 'external_list', 'external_list');
+
+        await vault.writeMetadata(author);
+        expect(await vault.verify()).toBe(true);
+
+        const re_open = new Vault(storage_driver, vault.id);
+        await re_open.loadMetadata();
+        expect(await re_open.verify()).toBe(true);
+
+        const re_open_container = re_open.getOrCreateContainer(author, 'external_list', 'external_list');
+
+        expect(await re_open_container.decryptContents(author)).toEqual([]);
+    });
+
     it(`can add a file container`, async () => {
         let author = Wallet.generate_entity();
 

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -313,9 +313,12 @@ export abstract class EmbeddedContainer extends Container {
 
             for (const idx in this.meta.roles) {
                 const role = this.meta.roles[idx];
-                // TODO: Try/Catch Encryption
-                const _encrypted_data = await this.vault.encryptForRole(role, unencrypted);
-                this.encrypted_contents[role] = _encrypted_data.to_string;
+                try {
+                    const _encrypted_data = await this.vault.encryptForRole(role, unencrypted);
+                    this.encrypted_contents[role] = _encrypted_data.to_string;
+                } catch (_err) {
+                    throw new Error('Unable to encrypt vault data (' + _err.message + ')');
+                }
             }
         }
 
@@ -467,9 +470,13 @@ export abstract class ExternalContainer extends Container {
 
         for (const idx in this.meta.roles) {
             const role = this.meta.roles[idx];
-            // TODO: Try/Catch Encryption
-            const _encrypted_data = await this.vault.encryptForRole(role, unencrypted);
-            this.encrypted_contents[role] = _encrypted_data.to_string;
+
+            try {
+                const _encrypted_data = await this.vault.encryptForRole(role, unencrypted);
+                this.encrypted_contents[role] = _encrypted_data.to_string;
+            } catch (_err) {
+                throw new Error('Unable to encrypt vault data (' + _err.message + ')');
+            }
         }
     }
 

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -307,7 +307,7 @@ export abstract class EmbeddedContainer extends Container {
     abstract getRawContents();
 
     async encryptContents() {
-        if(this.modified_raw_contents) {
+        if(this.modified_raw_contents || Object.keys(this.encrypted_contents).length === 0 ) {
             const unencrypted = this.getRawContents();
             this.encrypted_contents = {};
 


### PR DESCRIPTION
Embedded containers that did not get initialized with data are being stored as invalid containers and throw errors when accessed.

This change fully initializes embedded containers within a vault if no content is added prior to encryption and writing to the storage driver.