### PR TITLE
Events for a Subscription can incorrectly be sent multiple times

### DIFF
--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -270,21 +270,26 @@ export class EventSubscription extends BaseEntity {
                                         if (response.statusCode != 200 && response.statusCode != 204) {
                                             logger.error(`Transaction Callback Failed with ${response.statusCode}`);
                                             await eventSubscription.failed();
+                                            resolve();
                                         } else {
                                             await eventSubscription.success(highestBlock);
+                                            resolve();
                                         }
                                     })
                                     .on('error', async function(err) {
                                         logger.error(`${err}`);
                                         await eventSubscription.failed();
+                                        resolve();
                                     });
                             } catch (_err) {
                                 logger.error(`Error posting events to ${eventSubscription.url} ${_err}`);
                                 await eventSubscription.failed();
+                                resolve();
                             }
+                        } else {
+                            resolve();
                         }
 
-                        resolve();
                     },
                 );
             });

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -265,10 +265,11 @@ export class EventSubscription extends BaseEntity {
                                     .post({
                                         url: eventSubscription.url,
                                         json: events,
+                                        timeout: 60000,
                                     })
                                     .on('response', async function(response) {
                                         if (response.statusCode != 200 && response.statusCode != 204) {
-                                            logger.error(`Transaction Callback Failed with ${response.statusCode}`);
+                                            logger.error(`Event Subscription Failed with ${response.statusCode} [${eventSubscription.url}]`);
                                             await eventSubscription.failed();
                                             resolve();
                                         } else {
@@ -277,7 +278,7 @@ export class EventSubscription extends BaseEntity {
                                         }
                                     })
                                     .on('error', async function(err) {
-                                        logger.error(`${err}`);
+                                        logger.error(`Event Subscription Failed with ${err} [${eventSubscription.url}]`);
                                         await eventSubscription.failed();
                                         resolve();
                                     });


### PR DESCRIPTION
If the subscriber takes longer than the subscription interval to respond to the post containing the events, then the AsyncPoll may fire again and send the same events.  Engine needs to prevent re-firing the AsyncPoll if the first is still waiting.  Additionally a timeout of 60 seconds has been added to the event POST requests.