### PR TITLE
Enable SSL, mutual certificate authentication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="Lucas Clay <lclay@shipchain.io>"
 ENV LANG C.UTF-8
 ENV PYTHONUNBUFFERED 1
 
-RUN apt-get update -y && apt-get install -y libgmp3-dev libstdc++6
+RUN apt-get update -y && apt-get install -y libgmp3-dev libstdc++6 jq
 
 # SUPPORT SSH FOR IAM USERS #
 RUN apt-get update && apt-get -y install openssh-server python3-pip
@@ -17,6 +17,8 @@ RUN keymaker install
 RUN echo "AllowAgentForwarding yes" >> /etc/ssh/sshd_config
 RUN echo "PasswordAuthentication no" >> /etc/ssh/sshd_config
 # ------------------------- #
+
+RUN pip3 install awscli
 
 RUN mkdir /app
 WORKDIR /app

--- a/compose/nginx/Dockerfile
+++ b/compose/nginx/Dockerfile
@@ -1,0 +1,14 @@
+FROM nginx
+
+LABEL maintainer="Adam Hodges <ahodges@shipchain.io>"
+
+RUN apt-get update
+RUN apt-get install -y python-pip jq
+RUN pip install awscli
+
+RUN mkdir -p /etc/nginx/certs
+ADD ./nginx.conf /etc/nginx/conf.d/default.conf
+
+COPY ./*.sh /
+RUN chmod +x /*.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/compose/nginx/entrypoint.sh
+++ b/compose/nginx/entrypoint.sh
@@ -38,7 +38,7 @@ echo "Copying certificate to nginx"
 echo $CERT_JSON | jq -r '.Certificate' >> /etc/nginx/certs/$SUBDOMAIN.crt
 echo $CERT_JSON | jq -r '.CertificateChain' >> /etc/nginx/certs/$SUBDOMAIN.crt
 echo $CERT_JSON | jq -r '.PrivateKey' > /etc/nginx/certs/$SUBDOMAIN.encrypted.key
-echo $CA_CERT_JSON | jq -r '.Certificate' >> //etc/nginx/certs/ca-bundle.crt
+echo $CA_CERT_JSON | jq -r '.Certificate' >> /etc/nginx/certs/ca-bundle.crt
 echo $CA_CERT_JSON | jq -r '.CertificateChain' >> /etc/nginx/certs/ca-bundle.crt
 # Decrypt key
 openssl rsa -passin pass:$CERT_PASS -in /etc/nginx/certs/$SUBDOMAIN.encrypted.key -out /etc/nginx/certs/$SUBDOMAIN.key

--- a/compose/nginx/entrypoint.sh
+++ b/compose/nginx/entrypoint.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+SUBDOMAIN=$APP.${ENV,,}-internal
+
+echo "Looking for existing certificate in ACM"
+CERT_ARN=$(aws acm list-certificates | jq -r "[.CertificateSummaryList[] | select(.DomainName == \"$SUBDOMAIN\")][0].CertificateArn")
+
+# Create private certificate in AWS ACM
+if [ $CERT_ARN = "null" ];
+then
+    echo "Creating new certificate"
+    CERT_ARN=$(aws --region us-east-1 acm request-certificate \
+    --domain-name $SUBDOMAIN \
+    --idempotency-token $APP$ENV \
+    --options CertificateTransparencyLoggingPreference=DISABLED \
+    --certificate-authority-arn $CERT_AUTHORITY_ARN | jq -r '.CertificateArn')
+
+    echo "Waiting for certificate to be ready"
+    STATUS=$(aws acm describe-certificate --certificate-arn $CERT_ARN | jq -r '.Certificate.Status')
+    while [ $STATUS != "ISSUED" ] && [ $STATUS != "FAILED" ]
+    do
+      sleep 2
+      STATUS=$(aws acm describe-certificate --certificate-arn $CERT_ARN | jq -r '.Certificate.Status')
+    done
+
+    echo "Tagging certificate"
+    aws acm add-tags-to-certificate --certificate-arn $CERT_ARN --tags Key=Name,Value=$SUBDOMAIN
+fi
+
+# Export certificate as JSON
+echo "Exporting certificate"
+CERT_PASS=$(openssl rand --base64 12)
+CERT_JSON=$(aws --region us-east-1 acm export-certificate --certificate-arn $CERT_ARN --passphrase $CERT_PASS)
+CA_CERT_JSON=$(aws --region us-east-1 acm-pca get-certificate-authority-certificate --certificate-authority-arn $CERT_AUTHORITY_ARN)
+
+# Copy certificate to nginx
+echo "Copying certificate to nginx"
+echo $CERT_JSON | jq -r '.Certificate' >> /etc/nginx/certs/$SUBDOMAIN.crt
+echo $CERT_JSON | jq -r '.CertificateChain' >> /etc/nginx/certs/$SUBDOMAIN.crt
+echo $CERT_JSON | jq -r '.PrivateKey' > /etc/nginx/certs/$SUBDOMAIN.encrypted.key
+echo $CA_CERT_JSON | jq -r '.Certificate' >> //etc/nginx/certs/ca-bundle.crt
+echo $CA_CERT_JSON | jq -r '.CertificateChain' >> /etc/nginx/certs/ca-bundle.crt
+# Decrypt key
+openssl rsa -passin pass:$CERT_PASS -in /etc/nginx/certs/$SUBDOMAIN.encrypted.key -out /etc/nginx/certs/$SUBDOMAIN.key
+
+# Update nginx.conf with app name and environment
+sed -i "s/#{DOMAIN}/$SUBDOMAIN/g" /etc/nginx/conf.d/default.conf
+
+exec "$@"

--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -1,0 +1,27 @@
+upstream node {
+    server 127.0.0.1:2000;
+}
+
+server {
+    listen 443 ssl;
+    server_name ~^(.+)$;
+    charset utf-8;
+
+    ssl_certificate     certs/#{DOMAIN}.crt;
+    ssl_certificate_key certs/#{DOMAIN}.key;
+
+    ssl_client_certificate certs/ca-bundle.crt;
+    ssl_verify_client on;
+    ssl_verify_depth 2;
+
+    client_max_body_size 25m;
+
+    location / {
+        proxy_pass http://node;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}

--- a/compose/scripts/download-certs.sh
+++ b/compose/scripts/download-certs.sh
@@ -1,0 +1,44 @@
+SUBDOMAIN=$APP.${ENV,,}-internal
+
+echo "Looking for existing certificate in ACM"
+CERT_ARN=$(aws acm list-certificates | jq -r "[.CertificateSummaryList[] | select(.DomainName == \"$SUBDOMAIN\")][0].CertificateArn")
+
+# Create private certificate in AWS ACM
+if [ $CERT_ARN = "null" ];
+then
+    echo "Creating new certificate"
+    CERT_ARN=$(aws --region us-east-1 acm request-certificate \
+    --domain-name $SUBDOMAIN \
+    --idempotency-token $APP$ENV \
+    --options CertificateTransparencyLoggingPreference=DISABLED \
+    --certificate-authority-arn $CERT_AUTHORITY_ARN | jq -r '.CertificateArn')
+
+    echo "Waiting for certificate to be ready"
+    STATUS=$(aws acm describe-certificate --certificate-arn $CERT_ARN | jq -r '.Certificate.Status')
+    while [ $STATUS != "ISSUED" ] && [ $STATUS != "FAILED" ]
+    do
+      sleep 2
+      STATUS=$(aws acm describe-certificate --certificate-arn $CERT_ARN | jq -r '.Certificate.Status')
+    done
+
+    echo "Tagging certificate"
+    aws acm add-tags-to-certificate --certificate-arn $CERT_ARN --tags Key=Name,Value=$SUBDOMAIN
+fi
+
+# Export certificate as JSON
+echo "Exporting certificate"
+CERT_PASS=$(openssl rand --base64 12)
+CERT_JSON=$(aws --region us-east-1 acm export-certificate --certificate-arn $CERT_ARN --passphrase $CERT_PASS)
+CA_CERT_JSON=$(aws --region us-east-1 acm-pca get-certificate-authority-certificate --certificate-authority-arn $CERT_AUTHORITY_ARN)
+
+# Copy certificate to nodejs
+echo "Copying certificate to nodejs"
+echo $CERT_JSON | jq -r '.Certificate' >> /app/client-cert.crt
+echo $CERT_JSON | jq -r '.CertificateChain' >> /app/client-cert.crt
+echo $CERT_JSON | jq -r '.PrivateKey' > /app/client-cert.encrypted.key
+echo $CA_CERT_JSON | jq -r '.Certificate' >> /app/ca-bundle.crt
+echo $CA_CERT_JSON | jq -r '.CertificateChain' >> /app/ca-bundle.crt
+
+# Decrypt key
+openssl rsa -passin pass:$CERT_PASS -in /app/client-cert.encrypted.key -out /app/client-cert.key
+chmod 644 /app/client-cert.key  # Change permission level so Node can read it

--- a/compose/scripts/entrypoint.sh
+++ b/compose/scripts/entrypoint.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
 
+if [ "$ENV" = "PROD" ] || [ "$ENV" = "STAGE" ] || [ "$ENV" = "DEV" ];
+then
+  /download-certs.sh
+fi
+
+# Run migrations
 npm run migrate
 exec "$@"

--- a/compose/scripts/entrypoint.sh
+++ b/compose/scripts/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ "$ENV" = "PROD" ] || [ "$ENV" = "STAGE" ] || [ "$ENV" = "DEV" ];
+if [ "$ENV" = "PROD" ] || [ "$ENV" = "DEMO" ] || [ "$ENV" = "STAGE" ] || [ "$ENV" = "DEV" ];
 then
   /download-certs.sh
 fi

--- a/compose/scripts/ssh-entrypoint.sh
+++ b/compose/scripts/ssh-entrypoint.sh
@@ -2,11 +2,14 @@
 
 # Copy ECS env vars into bash profile so they're available to SSH'd users
 echo "export ENV=$ENV" >> /etc/profile
+echo "export CERT_AUTHORITY_ARN=$CERT_AUTHORITY_ARN" >> /etc/profile
 echo "export GETH_NODE=$GETH_NODE" >> /etc/profile
 echo "export SERVICE=$SERVICE" >> /etc/profile
 echo "export REDIS_URL=$REDIS_URL" >> /etc/profile
 echo "export AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" >> /etc/profile
 sed -i -e "2iexport AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI\\" /usr/sbin/keymaker-get-public-keys
 sed -i -e "2iexport AWS_CONTAINER_CREDENTIALS_RELATIVE_URI=$AWS_CONTAINER_CREDENTIALS_RELATIVE_URI\\" /usr/local/bin/keymaker-create-account-for-iam-user
+
+/download-certs.sh
 
 exec "$@"

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -18,6 +18,7 @@ import { BaseEntity, Column, CreateDateColumn, Entity, getConnection, PrimaryCol
 import { Contract } from './Contract';
 import { EventEmitter } from 'events';
 import { Logger, loggers } from 'winston';
+import { getRequestOptions } from '../request-options';
 
 const request = require('request');
 
@@ -261,12 +262,15 @@ export class EventSubscription extends BaseEntity {
                             );
 
                             try {
+                                let options = {
+                                    url: eventSubscription.url,
+                                    json: events,
+                                    timeout: 60000,
+                                }
+                                options = Object.assign(options, getRequestOptions());
+
                                 request
-                                    .post({
-                                        url: eventSubscription.url,
-                                        json: events,
-                                        timeout: 60000,
-                                    })
+                                    .post(options)
                                     .on('response', async function(response) {
                                         if (response.statusCode != 200 && response.statusCode != 204) {
                                             logger.error(`Event Subscription Failed with ${response.statusCode} [${eventSubscription.url}]`);

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -267,7 +267,7 @@ export class EventSubscription extends BaseEntity {
                                     json: events,
                                     timeout: 60000,
                                 }
-                                options = Object.assign(options, getRequestOptions());
+                                options = Object.assign(options, await getRequestOptions());
 
                                 request
                                     .post(options)

--- a/src/request-options.ts
+++ b/src/request-options.ts
@@ -34,7 +34,7 @@ export async function getRequestOptions() {
         options = {
           cert: fs.readFileSync(certFile),
           key: fs.readFileSync(keyFile),
-          ca: fs.readFileSync(caFile)
+          ca: [ fs.readFileSync(caFile) ]
         }
       }
       return options;

--- a/src/request-options.ts
+++ b/src/request-options.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var fs = require('fs')
+    , certFile = '/app/client-cert.crt'
+    , keyFile = '/app/client-cert.key'
+    , caFile = '/app/ca-bundle.crt';
+
+import { Logger, loggers } from "winston";
+
+// @ts-ignore
+const logger: Logger = loggers.get('engine');
+const ENV = process.env.ENV || "LOCAL";
+
+let options = null;
+
+export async function getRequestOptions() {
+
+    if (ENV === "DEV" || ENV === "STAGE" || ENV === "PROD") {
+      if (!options) {
+        options = {
+          cert: fs.readFileSync(certFile),
+          key: fs.readFileSync(keyFile),
+          ca: fs.readFileSync(caFile)
+        }
+      }
+      return options;
+    }
+
+    else {
+        logger.info(`Skipping certificate loading for ${ENV}`);
+        return {};
+    }
+
+}

--- a/src/request-options.ts
+++ b/src/request-options.ts
@@ -29,7 +29,7 @@ let options = null;
 
 export async function getRequestOptions() {
 
-    if (ENV === "DEV" || ENV === "STAGE" || ENV === "PROD") {
+    if (ENV === "DEV" || ENV === "STAGE" || ENV === "DEMO" || ENV === "PROD") {
       if (!options) {
         options = {
           cert: fs.readFileSync(certFile),

--- a/src/request-options.ts
+++ b/src/request-options.ts
@@ -34,7 +34,7 @@ export async function getRequestOptions() {
         options = {
           cert: fs.readFileSync(certFile),
           key: fs.readFileSync(keyFile),
-          ca: [ fs.readFileSync(caFile) ]
+          ca: fs.readFileSync(caFile)
         }
       }
       return options;

--- a/src/shipchain/TransmissionConfirmationCallback.ts
+++ b/src/shipchain/TransmissionConfirmationCallback.ts
@@ -47,7 +47,7 @@ export class TransmissionConfirmationCallback extends ContractCallback {
                 url: this.url,
                 json: body,
             }
-            options = Object.assign(options, getRequestOptions());
+            options = Object.assign(options, await getRequestOptions());
 
             request
                 .post(options)

--- a/src/shipchain/TransmissionConfirmationCallback.ts
+++ b/src/shipchain/TransmissionConfirmationCallback.ts
@@ -15,6 +15,7 @@
  */
 
 import { ContractCallback } from '../contracts/ContractCallback';
+import { getRequestOptions } from '../request-options';
 import { Logger, loggers } from 'winston';
 
 // @ts-ignore
@@ -42,11 +43,14 @@ export class TransmissionConfirmationCallback extends ContractCallback {
 
     private async postData(body: any) {
         try {
+            let options = {
+                url: this.url,
+                json: body,
+            }
+            options = Object.assign(options, getRequestOptions());
+
             request
-                .post({
-                    url: this.url,
-                    json: body,
-                })
+                .post(options)
                 .on('response', function(response) {
                     if (response.statusCode != 204) {
                         logger.error(`Transaction Callback Failed with ${response.statusCode}`);


### PR DESCRIPTION
These changes are required for Engine to work with our SSL mututal certificate auth infrastructure changes.
- Add Nginx Dockerfile and config for SSL
- Add entrypoint scripts to load certificates from AWS ACM in deployed environments
- Add request-options.ts, which loads client certificates for `request`.