### PR TITLE
Documents Container in LoadVault

### DIFF
--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -73,6 +73,7 @@ services:
       - ELASTICSEARCH_URL
       - INFLUXDB_URL
       - LOCAL_SECRET_KEY
+      - LOGGING_LEVEL
 
 networks:
   portal:

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -92,7 +92,11 @@ server.expose("load", {
     "get_tracking_data": RPCLoad.GetTrackingData,
     "add_tracking_data": RPCLoad.AddTrackingData,
     "get_shipment_data": RPCLoad.GetShipmentData,
-    "add_shipment_data": RPCLoad.AddShipmentData
+    "add_shipment_data": RPCLoad.AddShipmentData,
+    "get_document": RPCLoad.GetDocument,
+    "add_document": RPCLoad.AddDocument,
+    "list_documents": RPCLoad.ListDocuments,
+    "verify_vault": RPCLoad.VerifyVault,
 });
 
 server.expose("event", {

--- a/rpc/load.ts
+++ b/rpc/load.ts
@@ -425,4 +425,89 @@ export class RPCLoad {
             vault_signed: signature,
         };
     }
+
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault', 'documentName'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+        },
+    })
+    public static async GetDocument(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const load = new LoadVault(storage, args.vault);
+        const contents = await load.getDocument(wallet, args.documentName);
+
+        return {
+            success: true,
+            wallet_id: wallet.id,
+            load_id: args.vault,
+            document: contents,
+        };
+    }
+
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault', 'documentName', 'documentContent'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+        },
+    })
+    public static async AddDocument(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const load = new LoadVault(storage, args.vault);
+
+        await load.getOrCreateMetadata(wallet);
+        await load.addDocument(wallet, args.documentName, args.documentContent);
+        const signature = await load.writeMetadata(wallet);
+
+        return {
+            success: true,
+            vault_signed: signature,
+        };
+    }
+
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+        },
+    })
+    public static async ListDocuments(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const load = new LoadVault(storage, args.vault);
+
+        await load.getOrCreateMetadata(wallet);
+        const list = await load.listDocuments();
+
+        return {
+            success: true,
+            documents: list,
+        };
+    }
+
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+        },
+    })
+    public static async VerifyVault(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const load = new LoadVault(storage, args.vault);
+
+        await load.getOrCreateMetadata(wallet);
+        const verified = await load.verify();
+
+        return {
+            success: true,
+            verified: verified,
+        };
+    }
 }

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -58,7 +58,7 @@ export class AsyncPoll extends EventEmitter {
             this.activeTimeout = setTimeout(() => {
                 // If the interval fires but we've triggered a stop, make sure we don't emit
                 if (!this.stopPolling) {
-                    logger.debug(`Emitting poll for ${this.name}`);
+                    logger.silly(`Emitting poll for ${this.name}`);
                     this.emit('poll');
                 }
             }, this.interval);
@@ -119,7 +119,7 @@ export class EventSubscription extends BaseEntity {
             eventSubscriber.lastBlock = attrs.lastBlock || eventSubscriber.lastBlock;
             eventSubscriber.interval = attrs.interval || eventSubscriber.interval;
             eventSubscriber.errorCount = 0;
-            logger.debug(`Updating existing Subscription ${eventSubscriber}`);
+            logger.debug(`Updating existing Subscription ${JSON.stringify(eventSubscriber)}`);
         } catch (error) {
             eventSubscriber = new EventSubscription();
             eventSubscriber.url = attrs.url;
@@ -128,7 +128,7 @@ export class EventSubscription extends BaseEntity {
             eventSubscriber.lastBlock = attrs.lastBlock || 0;
             eventSubscriber.interval = attrs.interval || EventSubscription.DEFAULT_INTERVAL;
             eventSubscriber.errorCount = 0;
-            logger.debug(`Creating new Subscription ${eventSubscriber}`);
+            logger.debug(`Creating new Subscription ${JSON.stringify(eventSubscriber)}`);
         }
 
         EventSubscription.activeSubscriptions[attrs.url] = eventSubscriber;
@@ -236,7 +236,7 @@ export class EventSubscription extends BaseEntity {
     private static buildPoll(eventSubscription: EventSubscription, eventName: string) {
         async function pollMethod() {
             return new Promise((resolve, reject) => {
-                logger.debug(
+                logger.silly(
                     `Searching for Events fromBlock ${
                         eventSubscription.lastBlock ? +eventSubscription.lastBlock + 1 : 0
                     }`,
@@ -253,9 +253,8 @@ export class EventSubscription extends BaseEntity {
                             reject(error);
                         }
 
-                        logger.debug(`Found ${events.length} Events`);
-
                         if (events.length) {
+                            logger.info(`Found ${events.length} Events`);
                             let highestBlock = EventSubscription.findHighestBlockInEvents(
                                 events,
                                 eventSubscription.lastBlock,
@@ -266,7 +265,7 @@ export class EventSubscription extends BaseEntity {
                                     url: eventSubscription.url,
                                     json: events,
                                     timeout: 60000,
-                                }
+                                };
                                 options = Object.assign(options, await getRequestOptions());
 
                                 request
@@ -292,6 +291,7 @@ export class EventSubscription extends BaseEntity {
                                 resolve();
                             }
                         } else {
+                            logger.silly(`Found ${events.length} Events`);
                             resolve();
                         }
 

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -26,25 +26,39 @@ export class LoadVault extends Vault {
         await super.initializeMetadata(author);
         this.getOrCreateContainer(author, 'tracking', 'embedded_list');
         this.getOrCreateContainer(author, 'shipment', 'embedded_file');
+        this.getOrCreateContainer(author, 'documents', 'external_file_multi');
         return this.meta;
     }
 
-    async addTrackingData(author, payload) {
+    async addTrackingData(author: Wallet, payload) {
         await this.containers.tracking.append(author, payload);
     }
 
-    async getTrackingData(author) {
+    async getTrackingData(author: Wallet) {
         await this.loadMetadata();
         return await this.containers.tracking.decryptContents(author);
     }
 
-    async addShipmentData(author, shipment) {
+    async addShipmentData(author: Wallet, shipment) {
         await this.containers.shipment.setContents(author, JSON.stringify(shipment));
     }
 
-    async getShipmentData(author) {
+    async getShipmentData(author: Wallet) {
         await this.loadMetadata();
         const contents = await this.containers.shipment.decryptContents(author);
         return JSON.parse(contents);
+    }
+
+    async addDocument(author: Wallet, name: string, document: any) {
+        await this.containers.documents.setSingleContent(author, name, document);
+    }
+
+    async getDocument(author: Wallet, name: string) {
+        await this.loadMetadata();
+        return await this.containers.documents.decryptContents(author, name);
+    }
+
+    async listDocuments() {
+        return await this.containers.documents.listFiles();
     }
 }

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -294,6 +294,16 @@ export abstract class Container {
     }
 }
 
+interface ListContentContainer {
+    append(author: Wallet, blob: any);
+}
+interface SingleContentContainer {
+    setContents(author: Wallet, blob: any);
+}
+interface MultiContentContainer {
+    setSingleContent(author: Wallet, fileName: string, blob: any);
+}
+
 export abstract class EmbeddedContainer extends Container {
     public container_type: string;
     public raw_contents: any = null;
@@ -364,7 +374,7 @@ export abstract class EmbeddedContainer extends Container {
     }
 }
 
-export class EmbeddedFileContainer extends EmbeddedContainer {
+export class EmbeddedFileContainer extends EmbeddedContainer implements SingleContentContainer {
     public container_type: string = 'embedded_file';
 
     constructor(vault: Vault, name: string, meta?) {
@@ -388,7 +398,7 @@ export class EmbeddedFileContainer extends EmbeddedContainer {
     }
 }
 
-export class EmbeddedListContainer extends EmbeddedContainer {
+export class EmbeddedListContainer extends EmbeddedContainer implements ListContentContainer {
     public container_type: string = 'embedded_list';
 
     constructor(vault: Vault, name: string, meta?) {
@@ -579,7 +589,7 @@ export abstract class ExternalContainer extends Container {
     }
 }
 
-export class ExternalFileContainer extends ExternalContainer {
+export class ExternalFileContainer extends ExternalContainer implements SingleContentContainer  {
     public container_type: string = 'external_file';
 
     setContents(author: Wallet, blob: any) {
@@ -594,7 +604,7 @@ export class ExternalFileContainer extends ExternalContainer {
     }
 }
 
-export class ExternalListContainer extends ExternalContainer {
+export class ExternalListContainer extends ExternalContainer implements ListContentContainer {
     public container_type: string = 'external_list';
 
     async append(author: Wallet, blob) {
@@ -690,7 +700,7 @@ export abstract class ExternalDirectoryContainer extends ExternalContainer {
     }
 }
 
-export class ExternalListDailyContainer extends ExternalDirectoryContainer {
+export class ExternalListDailyContainer extends ExternalDirectoryContainer implements ListContentContainer {
     public container_type: string = 'external_list_daily';
 
     static getCurrentDayProperty(): string {


### PR DESCRIPTION
The LoadVault needs to support storing multiple Documents in a single, external container.  This is being achieved through a new container named `documents` of type `ExternalFileMultiContainer`.

Existing logic to support multiple files in the `ExternalListDailyContainer` was extracted to a new abstract class `ExternalDirectoryContainer` to better support subfolders in a container.  Like the existing ExternalListDailyContainer, any changes to the external files or their related signature in the main `meta.json` will cause vault verification to fail, signalling the data has been tampered with.

Additionally this includes enhancements to logging in Vaults and EventSubscriptions