### PR TITLE
Increase Event Subscription Error Threshold

### DIFF
--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -98,8 +98,7 @@ export class EventSubscription extends BaseEntity {
     private contractDriver: any;
     private asyncPolls: AsyncPoll[] = [];
 
-    static SECONDS = 1000;
-    static DEFAULT_INTERVAL = 30 * EventSubscription.SECONDS;
+    static DEFAULT_INTERVAL = 30 * SECONDS;
     static ERROR_THRESHOLD = 30;
 
     private static activeSubscriptions: EventSubscription[] = [];
@@ -264,7 +263,7 @@ export class EventSubscription extends BaseEntity {
                                 let options = {
                                     url: eventSubscription.url,
                                     json: events,
-                                    timeout: 60000,
+                                    timeout: 60 * SECONDS,
                                 };
                                 options = Object.assign(options, await getRequestOptions());
 

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -100,7 +100,7 @@ export class EventSubscription extends BaseEntity {
 
     static SECONDS = 1000;
     static DEFAULT_INTERVAL = 30 * EventSubscription.SECONDS;
-    static ERROR_THRESHOLD = 3;
+    static ERROR_THRESHOLD = 30;
 
     private static activeSubscriptions: EventSubscription[] = [];
 


### PR DESCRIPTION
Increase Error threshold in Event Subscription callback

Due to changes in DNS resolution of Transmission in ShipChain's infrastructure, we need to increase the number of attempts to contact Event Subscribers to allow for DNS propagation to fully complete.