### PR TITLE
Disabled local storage in prod and invalid storage type

### DIFF
--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -31,8 +31,7 @@ export class RPCStorageCredentials {
 
         // Local driver type is disabled in environment other than LOCAL
         // and storage credentials creation is disabled for unrecognizable driver type
-        const notAllowedStorage = (ENV != 'LOCAL' && args.driver_type === 'local') || driverType.indexOf(args.driver_type) < 0;
-        if (notAllowedStorage){
+        if (ENV != 'LOCAL' && args.driver_type === 'local' || driverType.indexOf(args.driver_type) < 0){
             throw new Error(`Driver type: ${args.driver_type}, not allowed!`);
         }
 


### PR DESCRIPTION
Added conditional clause in rpc/storage_credentials to check deployed environment and driver type in creation.