### PR TITLE
Vault Ledger and Historical Retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
+    "moment": "^2.22.2",
     "node-fetch": "^2.1.2",
     "pg": "^7.4.3",
     "read-source-stream": "^1.0.4",

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -97,6 +97,10 @@ server.expose("load", {
     "add_document": RPCLoad.AddDocument,
     "list_documents": RPCLoad.ListDocuments,
     "verify_vault": RPCLoad.VerifyVault,
+
+    "get_historical_shipment_data": RPCLoad.GetHistoricalShipmentData,
+    "get_historical_tracking_data": RPCLoad.GetHistoricalTrackingData,
+    "get_historical_document": RPCLoad.GetHistoricalDocument,
 });
 
 server.expose("event", {

--- a/rpc/load.ts
+++ b/rpc/load.ts
@@ -511,4 +511,67 @@ export class RPCLoad {
             verified: verified,
         };
     }
+
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+        },
+    })
+    public static async GetHistoricalShipmentData(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const load = new LoadVault(storage, args.vault);
+        const contents = await load.getHistoricalShipment(wallet, args.date);
+
+        return {
+            success: true,
+            wallet_id: wallet.id,
+            load_id: args.vault,
+            historical_data: contents,
+        };
+    }
+
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+        },
+    })
+    public static async GetHistoricalTrackingData(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const load = new LoadVault(storage, args.vault);
+        const contents = await load.getHistoricalTracking(wallet, args.date);
+
+        return {
+            success: true,
+            wallet_id: wallet.id,
+            load_id: args.vault,
+            historical_data: contents,
+        };
+    }
+
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+        },
+    })
+    public static async GetHistoricalDocument(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const load = new LoadVault(storage, args.vault);
+        const contents = await load.getHistoricalDocument(wallet, args.date, args.documentName);
+
+        return {
+            success: true,
+            wallet_id: wallet.id,
+            load_id: args.vault,
+            historical_data: contents,
+        };
+    }
 }

--- a/rpc/load.ts
+++ b/rpc/load.ts
@@ -43,7 +43,7 @@ export class RPCLoad {
 
         if (args.carrierWallet) {
             const carrierWallet = await Wallet.getById(args.carrierWallet);
-            await vault.authorize(shipperWallet, 'owners', carrierWallet.public_key);
+            await vault.authorize(shipperWallet, LoadVault.OWNERS_ROLE, carrierWallet.public_key);
         }
 
         const signature = await vault.writeMetadata(shipperWallet);

--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -240,7 +240,7 @@ describe('Vaults', function() {
         await vault.getOrCreateMetadata(author);
         const container = vault.getOrCreateContainer(author, 'file_01.txt');
 
-        container.setContents(author, 'TEST EMBED');
+        await container.setContents(author, 'TEST EMBED');
 
         await vault.writeMetadata(author);
 
@@ -285,7 +285,7 @@ describe('Vaults', function() {
         await vault.getOrCreateMetadata(author);
         const container = vault.getOrCreateContainer(author, 'test_external', 'external_file');
 
-        container.setContents(author, 'TEST External');
+        await container.setContents(author, 'TEST External');
 
         await vault.writeMetadata(author);
 
@@ -305,8 +305,8 @@ describe('Vaults', function() {
         await vault.getOrCreateMetadata(author);
         const container = vault.getOrCreateContainer(author, 'test_external_file_multi', 'external_file_multi');
 
-        container.setSingleContent(author, 'file_01.txt', 'TEST External 1');
-        container.setSingleContent(author, 'file_02.txt', 'TEST External 2');
+        await container.setSingleContent(author, 'file_01.txt', 'TEST External 1');
+        await container.setSingleContent(author, 'file_02.txt', 'TEST External 2');
 
         expect(await vault.fileExists('test_external_file_multi/file_01.txt.json')).toBeFalsy();
         expect(await vault.fileExists('test_external_file_multi/file_02.txt.json')).toBeFalsy();

--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -114,20 +114,20 @@ describe('Vaults', function() {
         let vault = new Vault(storage_driver);
         await vault.getOrCreateMetadata(author);
 
-        expect(await vault.createRole(author, 'owners')).toBe(false);
+        expect(await vault.createRole(author, Vault.OWNERS_ROLE)).toBe(false);
 
-        expect(vault.authorized_for_role(author.public_key, 'owners')).toBe(true);
-        expect(vault.authorized_for_role(stranger.public_key, 'owners')).toBe(false);
+        expect(vault.authorized_for_role(author.public_key, Vault.OWNERS_ROLE)).toBe(true);
+        expect(vault.authorized_for_role(stranger.public_key, Vault.OWNERS_ROLE)).toBe(false);
 
         /* Anyone should be able to sign messages for owners */
-        const encrypted = (await vault.encryptForRole('owners', 'TeST')).to_string;
+        const encrypted = (await vault.encryptForRole(Vault.OWNERS_ROLE, 'TeST')).to_string;
 
         /* Only Author be able to read messages for owners */
         expect(await vault.decryptMessage(author, encrypted)).toBe('TeST');
 
         /* This stranger can't authorize himself... */
-        expect(await vault.authorize(stranger, 'owners', stranger.public_key)).toBe(false);
-        expect(vault.authorized_for_role(stranger.public_key, 'owners')).toBe(false);
+        expect(await vault.authorize(stranger, Vault.OWNERS_ROLE, stranger.public_key)).toBe(false);
+        expect(vault.authorized_for_role(stranger.public_key, Vault.OWNERS_ROLE)).toBe(false);
         try {
             await vault.decryptMessage(stranger, encrypted);
             fail('Should not have decrypted message');
@@ -136,8 +136,8 @@ describe('Vaults', function() {
         }
 
         /* But if the author lets him in... */
-        expect(await vault.authorize(author, 'owners', stranger.public_key)).toBe(true);
-        expect(vault.authorized_for_role(stranger.public_key, 'owners')).toBe(true);
+        expect(await vault.authorize(author, Vault.OWNERS_ROLE, stranger.public_key)).toBe(true);
+        expect(vault.authorized_for_role(stranger.public_key, Vault.OWNERS_ROLE)).toBe(true);
 
         /* He can read the data! */
         expect(await vault.decryptMessage(stranger, encrypted)).toBe('TeST');

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -53,17 +53,17 @@ const redlock = new Redlock(
 export default redlock;
 
 export async function ResourceLock(key: string, base_obj: any, method_to_lock: string, params: any = [], ttl: number = 5000): Promise<any> {
-    logger.debug(`Obtaining lock using key ${key} for duration of ${ttl} ms, using method ${method_to_lock}.`);
+    logger.silly(`Obtaining lock using key ${key} for duration of ${ttl} ms, using method ${method_to_lock}.`);
 
     return new Promise((resolve, reject) => {
         const lockAttemptTime = Date.now();
         redlock.lock(key, ttl).then(async function(lock) {
             const lockObtainTime = Date.now();
             metrics.methodTime("ResourceLock", lockObtainTime - lockAttemptTime);
-            logger.debug(`Locked using key ${key} for duration of ${ttl} ms using method ${method_to_lock}.`);
+            logger.silly(`Locked using key ${key} for duration of ${ttl} ms using method ${method_to_lock}.`);
 
             const method_return = await (base_obj[method_to_lock])(...params);
-            logger.debug(`Unlocking using key ${key} for duration of ${ttl} ms using method ${method_to_lock}.`);
+            logger.silly(`Unlocking using key ${key} for duration of ${ttl} ms using method ${method_to_lock}.`);
 
             lock.unlock();
 

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -27,7 +27,7 @@ export class LoadVault extends Vault {
         super(storage_driver, id);
     }
 
-    async initializeMetadata(author: Wallet) {
+    protected async initializeMetadata(author: Wallet) {
         await super.initializeMetadata(author);
         this.getOrCreateContainer(author, LoadVault.TRACKING, 'embedded_list');
         this.getOrCreateContainer(author, LoadVault.SHIPMENT, 'embedded_file');

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -70,7 +70,8 @@ export class LoadVault extends Vault {
     async getHistoricalShipment(author: Wallet, date: string){
         await this.loadMetadata();
         const contents =  await this.getHistoricalData(author, LoadVault.SHIPMENT, date);
-        return JSON.parse(contents);
+        contents.shipment = JSON.parse(contents.shipment);
+        return contents;
     }
 
     async getHistoricalTracking(author: Wallet, date: string){

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -66,4 +66,19 @@ export class LoadVault extends Vault {
     async listDocuments() {
         return await this.containers[LoadVault.DOCUMENTS].listFiles();
     }
+
+    async getHistoricalShipment(author: Wallet, date: string){
+        await this.loadMetadata();
+        return await this.getHistoricalData(author, LoadVault.SHIPMENT, date)
+    }
+
+    async getHistoricalTracking(author: Wallet, date: string){
+        await this.loadMetadata();
+        return await this.getHistoricalData(author, LoadVault.TRACKING, date)
+    }
+
+    async getHistoricalDocument(author: Wallet, date: string, documentName: string){
+        await this.loadMetadata();
+        return await this.getHistoricalData(author, LoadVault.DOCUMENTS, date, documentName)
+    }
 }

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -69,7 +69,8 @@ export class LoadVault extends Vault {
 
     async getHistoricalShipment(author: Wallet, date: string){
         await this.loadMetadata();
-        return await this.getHistoricalData(author, LoadVault.SHIPMENT, date)
+        const contents =  await this.getHistoricalData(author, LoadVault.SHIPMENT, date);
+        return JSON.parse(contents);
     }
 
     async getHistoricalTracking(author: Wallet, date: string){

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -75,11 +75,11 @@ export class LoadVault extends Vault {
 
     async getHistoricalTracking(author: Wallet, date: string){
         await this.loadMetadata();
-        return await this.getHistoricalData(author, LoadVault.TRACKING, date)
+        return await this.getHistoricalData(author, LoadVault.TRACKING, date);
     }
 
     async getHistoricalDocument(author: Wallet, date: string, documentName: string){
         await this.loadMetadata();
-        return await this.getHistoricalData(author, LoadVault.DOCUMENTS, date, documentName)
+        return await this.getHistoricalData(author, LoadVault.DOCUMENTS, date, documentName);
     }
 }

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -18,47 +18,52 @@ import { Vault } from '../vaults/Vault';
 import { Wallet } from '../entity/Wallet';
 
 export class LoadVault extends Vault {
+
+    private static readonly TRACKING: string = 'tracking';
+    private static readonly SHIPMENT: string = 'shipment';
+    private static readonly DOCUMENTS: string = 'documents';
+
     constructor(storage_driver, id?) {
         super(storage_driver, id);
     }
 
     async initializeMetadata(author: Wallet) {
         await super.initializeMetadata(author);
-        this.getOrCreateContainer(author, 'tracking', 'embedded_list');
-        this.getOrCreateContainer(author, 'shipment', 'embedded_file');
-        this.getOrCreateContainer(author, 'documents', 'external_file_multi');
+        this.getOrCreateContainer(author, LoadVault.TRACKING, 'embedded_list');
+        this.getOrCreateContainer(author, LoadVault.SHIPMENT, 'embedded_file');
+        this.getOrCreateContainer(author, LoadVault.DOCUMENTS, 'external_file_multi');
         return this.meta;
     }
 
     async addTrackingData(author: Wallet, payload) {
-        await this.containers.tracking.append(author, payload);
+        await this.containers[LoadVault.TRACKING].append(author, payload);
     }
 
     async getTrackingData(author: Wallet) {
         await this.loadMetadata();
-        return await this.containers.tracking.decryptContents(author);
+        return await this.containers[LoadVault.TRACKING].decryptContents(author);
     }
 
     async addShipmentData(author: Wallet, shipment) {
-        await this.containers.shipment.setContents(author, JSON.stringify(shipment));
+        await this.containers[LoadVault.SHIPMENT].setContents(author, JSON.stringify(shipment));
     }
 
     async getShipmentData(author: Wallet) {
         await this.loadMetadata();
-        const contents = await this.containers.shipment.decryptContents(author);
+        const contents = await this.containers[LoadVault.SHIPMENT].decryptContents(author);
         return JSON.parse(contents);
     }
 
     async addDocument(author: Wallet, name: string, document: any) {
-        await this.containers.documents.setSingleContent(author, name, document);
+        await this.containers[LoadVault.DOCUMENTS].setSingleContent(author, name, document);
     }
 
     async getDocument(author: Wallet, name: string) {
         await this.loadMetadata();
-        return await this.containers.documents.decryptContents(author, name);
+        return await this.containers[LoadVault.DOCUMENTS].decryptContents(author, name);
     }
 
     async listDocuments() {
-        return await this.containers.documents.listFiles();
+        return await this.containers[LoadVault.DOCUMENTS].listFiles();
     }
 }

--- a/src/shipchain/__tests__/loadvault.ts
+++ b/src/shipchain/__tests__/loadvault.ts
@@ -1,0 +1,188 @@
+/*
+ * Copyright 2018 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require('../../__tests__/testLoggingConfig');
+
+import 'mocha';
+import { createConnection } from 'typeorm';
+import { LoadVault } from '../LoadVault';
+import { Wallet } from '../../entity/Wallet';
+import { PrivateKeyDBFieldEncryption } from "../../encryption/PrivateKeyDBFieldEncryption";
+
+const storage_driver = { driver_type: 'local', base_path: 'storage/vault-tests' };
+
+
+describe('LoadVault', function() {
+    const RealDate = Date;
+
+    function mockDate(isoDate) {
+        // @ts-ignore
+        global.Date = class extends RealDate {
+            constructor() {
+                super();
+                return new RealDate(isoDate);
+            }
+        };
+    }
+
+    function resetDate() {
+        // @ts-ignore
+        global.Date = RealDate;
+    }
+
+    beforeEach(async () => {
+        this.connection = await createConnection({
+            type: 'sqljs',
+            synchronize: true,
+            entities: ['src/entity/**/*.ts'],
+        });
+
+        Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
+    });
+
+    afterEach(async () => {
+        await this.connection.dropDatabase();
+        if (this.connection.isConnected) {
+            await this.connection.close();
+        }
+        resetDate();
+    });
+
+    it(`can be created`, async () => {
+        let author = await Wallet.generate_entity();
+
+        /* New vault shouldn't exist yet */
+        let vault = new LoadVault(storage_driver);
+        expect(await vault.metadataFileExists()).toBe(false);
+
+        /* And then we can write the metadata */
+        await vault.getOrCreateMetadata(author);
+        expect(await vault.metadataFileExists()).toBe(true);
+
+        /* And delete it to clean up */
+        await vault.deleteMetadata();
+        expect(await vault.metadataFileExists()).toBe(false);
+    });
+
+    it('can add and retrieve Shipment data', async() => {
+        let author: Wallet = await Wallet.generate_entity();
+
+        /* New vault shouldn't exist yet */
+        let vault = new LoadVault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+
+        // Test with first set of Shipment fields
+        await vault.addShipmentData(author, SHIPMENT_01);
+        await vault.writeMetadata(author);
+
+        vault = new LoadVault(storage_driver, vault.id);
+        let testShipment = await vault.getShipmentData(author);
+
+        expect(testShipment).toEqual(SHIPMENT_01);
+
+        // Test with another set of Shipment fields
+        await vault.addShipmentData(author, SHIPMENT_02);
+        await vault.writeMetadata(author);
+
+        vault = new LoadVault(storage_driver, vault.id);
+        testShipment = await vault.getShipmentData(author);
+
+        expect(testShipment).toEqual(SHIPMENT_02);
+    });
+
+    it('can add and retrieve Tracking data', async() => {
+        let author: Wallet = await Wallet.generate_entity();
+
+        /* New vault shouldn't exist yet */
+        let vault = new LoadVault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+
+        // Test with a single point
+        await vault.addTrackingData(author, TRACKING_01);
+        await vault.writeMetadata(author);
+
+        vault = new LoadVault(storage_driver, vault.id);
+        let testTracking = await vault.getTrackingData(author);
+
+        expect(testTracking).toEqual([TRACKING_01]);
+
+        // Test with another point
+        await vault.addTrackingData(author, TRACKING_02);
+        await vault.writeMetadata(author);
+
+        vault = new LoadVault(storage_driver, vault.id);
+        testTracking = await vault.getTrackingData(author);
+
+        expect(testTracking).toEqual([TRACKING_01, TRACKING_02]);
+    });
+
+    it('can add and retrieve Documents', async() => {
+        let author: Wallet = await Wallet.generate_entity();
+
+        /* New vault shouldn't exist yet */
+        let vault = new LoadVault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+
+        // Test with first Document
+        await vault.addDocument(author, DOCUMENT_01.name, DOCUMENT_01.content);
+        await vault.writeMetadata(author);
+
+        vault = new LoadVault(storage_driver, vault.id);
+        let testDocument = await vault.getDocument(author, DOCUMENT_01.name);
+
+        expect(testDocument).toEqual(DOCUMENT_01.content);
+
+        // Test with another Document
+        await vault.addDocument(author, DOCUMENT_02.name, DOCUMENT_02.content);
+        await vault.writeMetadata(author);
+
+        vault = new LoadVault(storage_driver, vault.id);
+        testDocument = await vault.getDocument(author, DOCUMENT_02.name);
+
+        expect(testDocument).toEqual(DOCUMENT_02.content);
+
+        // List created Documents
+        let listing = await vault.listDocuments();
+        expect(listing).toEqual([{name: DOCUMENT_01.name},{name: DOCUMENT_02.name}]);
+    });
+
+});
+
+
+const SHIPMENT_01 = {
+    id: "14D6A86b-b52e-4CBE-93AE-CEA5bA90fAcb",
+    carrier_scac: "F49S",
+    customer_fields: {
+        u: "wot",
+        i: "swear on me"
+    }
+};
+const SHIPMENT_02 = {
+    id: "19ef431c-3b09-4df1-9faf-673951a602ab",
+    carrier_scac: "G50T"
+};
+
+const TRACKING_01 = {tracking: 1};
+const TRACKING_02 = {tracking: 2};
+
+const DOCUMENT_01 = {
+    name: 'file01.txt',
+    content: 'test file content 1'
+};
+const DOCUMENT_02 = {
+    name: 'file02.png',
+    content: 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mN8U+T4nYEIwDiqkL4KAZKnGefMCAbPAAAAAElFTkSuQmCC'
+};

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -351,14 +351,15 @@ export abstract class Container {
         throw new Error("Unknown Container type: '" + container_type + "'");
     }
 
-    authorize_role(author: Wallet, role: string) {
-        this.meta.roles.push(role);
-        this.vault.logAction(author, 'container.authorize_role', {
-            role,
-            container_type: this.container_type,
-            name: this.name,
-        });
-    }
+    // authorize_role(author: Wallet, role: string) {
+    //     this.meta.roles.push(role);
+    //     // Adding a role to a Container will need to re-encrypt the data for the new key
+    //     this.vault.logAction(author, 'container.authorize_role', {
+    //         role,
+    //         container_type: this.container_type,
+    //         name: this.name,
+    //     });
+    // }
 
     abstract async encryptContents();
 
@@ -1021,7 +1022,7 @@ export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
         const toDate: Moment = moment(date,
             [ExternalFileLedgerContainer.MOMENT_FORMAT, moment.ISO_8601],
             true
-        ).add("ms", 1);
+        ).add(1, "ms");
 
         if(!toDate.isValid()){
             throw new Error(`Invalid Date '${date}' not in format '${ExternalFileLedgerContainer.MOMENT_FORMAT}'`);
@@ -1033,15 +1034,14 @@ export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
         // Find the latest Ledger index before our toDate
         for (let property in this.meta) {
             if (this.meta.hasOwnProperty(property) && property.indexOf(this.name) !== -1) {
-                const checkDate: Moment = moment(this.meta[property].at,
+                const indexDate: Moment = moment(this.meta[property].at,
                     [ExternalFileLedgerContainer.MOMENT_FORMAT, moment.ISO_8601],
                     true);
-
-                if(!checkDate.isValid()){
+                if(!indexDate.isValid()){
                     throw new Error(`Vault Ledger data is invalid! [${container}.${property}]`);
                 }
 
-                if(checkDate.isBefore(toDate)){
+                if(indexDate.isBefore(toDate)){
                     // Remove the container name from the property
                     let thisIndex = property.split(path.sep)[1];
 

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -323,7 +323,7 @@ export abstract class Container {
     public container_type: string;
     protected modified_raw_contents: boolean = false;
 
-    constructor(vault: Vault, name: string, meta?: any) {
+    protected constructor(vault: Vault, name: string, meta?: any) {
         this.vault = vault;
         this.name = name;
         this.meta = meta || {
@@ -392,6 +392,7 @@ interface SingleContentContainer {
 }
 interface MultiContentContainer {
     setSingleContent(author: Wallet, fileName: string, blob: any);
+    listFiles();
 }
 
 export abstract class EmbeddedContainer extends Container {
@@ -399,7 +400,7 @@ export abstract class EmbeddedContainer extends Container {
     public raw_contents: any = null;
     public encrypted_contents: any = null;
 
-    constructor(vault: Vault, name: string, meta?: any) {
+    protected constructor(vault: Vault, name: string, meta?: any) {
         super(vault, name, meta);
         this.encrypted_contents = (meta && meta.encrypted_contents) ? meta.encrypted_contents : {};
     }
@@ -539,7 +540,7 @@ export abstract class ExternalContainer extends Container {
     public raw_contents: any = null;
     public encrypted_contents: any = null;
 
-    constructor(vault: Vault, name: string, meta?: any) {
+    protected constructor(vault: Vault, name: string, meta?: any) {
         super(vault, name, meta);
         this.encrypted_contents = null;
         this.raw_contents = [];
@@ -695,6 +696,10 @@ export abstract class ExternalContainer extends Container {
 export class ExternalFileContainer extends ExternalContainer implements SingleContentContainer  {
     public container_type: string = 'external_file';
 
+    constructor(vault: Vault, name: string, meta?: any) {
+        super(vault, name, meta);
+    }
+
     async setContents(author: Wallet, blob: any) {
         if (blob === null || blob === undefined || blob === '') {
             throw new Error('New Content cannot be empty');
@@ -709,6 +714,10 @@ export class ExternalFileContainer extends ExternalContainer implements SingleCo
 
 export class ExternalListContainer extends ExternalContainer implements ListContentContainer {
     public container_type: string = 'external_list';
+
+    constructor(vault: Vault, name: string, meta?: any) {
+        super(vault, name, meta);
+    }
 
     async append(author: Wallet, blob) {
         if (blob === null || blob === undefined || blob === '') {
@@ -743,7 +752,7 @@ export class ExternalListContainer extends ExternalContainer implements ListCont
 export abstract class ExternalDirectoryContainer extends ExternalContainer {
     protected modified_items: string[] = [];
 
-    constructor(vault: Vault, name: string, meta?: any) {
+    protected constructor(vault: Vault, name: string, meta?: any) {
         super(vault, name, meta);
         this.encrypted_contents = null;
         this.raw_contents = {};
@@ -805,6 +814,10 @@ export abstract class ExternalDirectoryContainer extends ExternalContainer {
 
 export class ExternalListDailyContainer extends ExternalDirectoryContainer implements ListContentContainer {
     public container_type: string = 'external_list_daily';
+
+    constructor(vault: Vault, name: string, meta?: any) {
+        super(vault, name, meta);
+    }
 
     static getCurrentDayProperty(): string {
         let today = new Date();
@@ -883,6 +896,10 @@ export class ExternalListDailyContainer extends ExternalDirectoryContainer imple
 
 export class ExternalFileMultiContainer extends ExternalDirectoryContainer implements MultiContentContainer {
     public container_type: string = 'external_file_multi';
+
+    constructor(vault: Vault, name: string, meta?: any) {
+        super(vault, name, meta);
+    }
 
     async setSingleContent(author: Wallet, fileName: string, blob: any) {
         if (blob === null || blob === undefined || blob === '') {

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -989,7 +989,7 @@ export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
                     // Single-file containers
                     else {
                         if (containerAction.indexOf('setcontents') != -1) {
-                            decryptedContainers[containerName] = JSON.parse(indexData.params);
+                            decryptedContainers[containerName] = indexData.params;
                             foundApplicableData = true;
                         }
                     }

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -441,7 +441,7 @@ export class EmbeddedFileContainer extends EmbeddedContainer implements SingleCo
         this.raw_contents = [];
     }
 
-    setContents(author: Wallet, blob: any) {
+    async setContents(author: Wallet, blob: any) {
         if (blob === null || blob === undefined || blob === '') {
             throw new Error('New Content cannot be empty');
         }
@@ -507,21 +507,21 @@ export abstract class ExternalContainer extends Container {
         this.raw_contents = [];
     }
 
-    getRawContents(contentIndex?: string) {
+    protected getRawContents(contentIndex?: string) {
         if(contentIndex){
             return this.raw_contents[contentIndex];
         }
         return this.raw_contents;
     }
 
-    getEncryptedContents(contentIndex?: string) {
+    protected getEncryptedContents(contentIndex?: string) {
         if(contentIndex){
             return this.encrypted_contents[contentIndex];
         }
         return this.encrypted_contents;
     }
 
-    setEncryptedContents(contents: any, subFile?: string){
+    protected setEncryptedContents(contents: any, subFile?: string){
         if(subFile){
             if(!this.encrypted_contents){
                 this.encrypted_contents = {};
@@ -657,7 +657,7 @@ export abstract class ExternalContainer extends Container {
 export class ExternalFileContainer extends ExternalContainer implements SingleContentContainer  {
     public container_type: string = 'external_file';
 
-    setContents(author: Wallet, blob: any) {
+    async setContents(author: Wallet, blob: any) {
         if (blob === null || blob === undefined || blob === '') {
             throw new Error('New Content cannot be empty');
         }
@@ -846,7 +846,7 @@ export class ExternalListDailyContainer extends ExternalDirectoryContainer imple
 export class ExternalFileMultiContainer extends ExternalDirectoryContainer implements MultiContentContainer {
     public container_type: string = 'external_file_multi';
 
-    setSingleContent(author: Wallet, fileName: string, blob: any) {
+    async setSingleContent(author: Wallet, fileName: string, blob: any) {
         if (blob === null || blob === undefined || blob === '') {
             throw new Error('New Content cannot be empty');
         }

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -210,7 +210,7 @@ export class Vault {
                 return await this.decryptWithRoleKey(wallet, role, message);
             }
             catch(err){
-                logger.debug(`Message decryption failed with role ${role}`);
+                logger.debug(`Message decryption failed with role ${role} (${err.message})`);
             }
         }
 

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -263,10 +263,10 @@ export class Vault {
         return await ResourceLock(this.id, this.driver, "listDirectory", [vaultDirectory, recursive]);
     }
 
-    getOrCreateContainer(author: Wallet, name: string, container_type?: string) {
+    getOrCreateContainer(author: Wallet, name: string, container_type?: string, meta?: any) {
         if (this.containers[name] instanceof Container) return this.containers[name];
         this.logAction(author, 'create_container', { name, container_type });
-        const container = Container.typeFactory(container_type || 'embedded_file', this, name);
+        const container = Container.typeFactory(container_type || 'embedded_file', this, name, meta);
         this.containers[name] = container;
         return container;
     }
@@ -343,7 +343,7 @@ export abstract class EmbeddedContainer extends Container {
 
     constructor(vault: Vault, name: string, meta?: any) {
         super(vault, name, meta);
-        this.encrypted_contents = meta ? meta.encrypted_contents : {};
+        this.encrypted_contents = (meta && meta.encrypted_contents) ? meta.encrypted_contents : {};
     }
 
     abstract getRawContents();

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -64,7 +64,7 @@ export class Vault {
         return this.meta;
     }
 
-    async initializeMetadata(author: Wallet, roles?) {
+    protected async initializeMetadata(author: Wallet, roles?) {
         this.meta = {
             id: this.id,
             version: '0.0.1',

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -172,12 +172,12 @@ export class Vault {
     authorized_roles(public_key: string) {
         const roles = [];
 
-        /* return OWNERS_ROLE first if we're an owner" */
+        // append OWNERS_ROLE first if we're an owner
         if (this.meta.roles[Vault.OWNERS_ROLE] && this.meta.roles[Vault.OWNERS_ROLE][public_key]) {
             roles.push(Vault.OWNERS_ROLE);
         }
 
-        /* or return the first role we are authorized for... */
+        // append remaining roles we are authorized for
         for (const role in this.meta.roles) {
             if (role != Vault.OWNERS_ROLE && this.meta.roles[role][public_key]){
                 roles.push(role);

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -730,7 +730,9 @@ export class ExternalListContainer extends ExternalContainer implements ListCont
         }
 
         const hash = utils.objectHash(blob);
-        if (!this.raw_contents.length && (this.encrypted_contents && Object.keys(this.encrypted_contents).length)) {
+        if (!this.raw_contents.length &&
+            this.meta[this.getExternalFilename()]
+        ) {
             await this.decryptContents(author);
         }
 


### PR DESCRIPTION
An Engine Vault needs the ability to reproduce its encrypted content from any point in its history.

The previous `actions` list in the vault is being replaced with a new `ledger` Role and Container.  This Ledger indexes every action taken across all containers in the vault.  Each entry contains information about the action: the type of container, the container name, the action in the container, and any data included as part of that action.  These entries are encrypted with the same logic as the other vault contents, except their key is from the `ledger` role.  By default, the vault owner (the Shipper) has access to pull historical data from the Ledger.

New RPC Endpoints are now available for utilizing this ledger in the LoadVault:
 - `get_historical_shipment_data`
 - `get_historical_tracking_data`
 - `get_historical_document`

Each of these RPC methods are invoked like their non-historical counterparts, except they require an additional parameter, `date`.  This new parameter is the date at which you wish to view the contents.  If no contents existed before the date you specify, you will receive an error indicating this.  The format of this new date field follows the ISO8601 standard `YYYY-MM-DDTHH:mm:ss.SSSZ`