### PR TITLE
Local S3 Storage Service with Minio

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,9 +134,9 @@ Testing is handled through the Docker containers as well and can be invoked via 
 
 By default the unit tests will use only the local directory for Storage Driver testing (used when managing Vaults).  However, advanced parameters are allowed which will enable either SFTP backed or S3 backed Storage Driver testing.
 
-In the `.env` file, include the following to enable SFTP tests using the bundled SFTP service in the Docker Compose file: `S3_DRIVER_TESTS=1`.
+In the `.env` file, include the following to enable SFTP tests using the bundled SFTP service in the Docker Compose file: `SFTP_DRIVER_TESTS=1`.
 
-If you want to test with your personal S3 Bucket, ensure you have the AWS credentials defined in your `.env` file (see Configuration section) and also include the following two variables `S3_DRIVER_TESTS=1` and `S3_BUCKET=<your_bucket>`.
+In the `.env` file, include the following to enable S3 tests using the bundled [Minio](https://www.minio.io/docker.html) S3 compatible service in the Docker Compose file: `S3_DRIVER_TESTS=1`.
 
 Run the unit tests via the provided script
 ```
@@ -281,6 +281,32 @@ These parameters are common to all Storage Credential creations:
   "id": 0
 }
 ```
+
+During local development, if you do not have or do not wish to use your own AWS S3 Buckets for storage, you can utilize the provided S3 compatible Minio service as a storage provider, use the following options:
+
+```JS
+{
+	"method": "storage_credentials.create_hosted",
+	"params": {
+		"title": "Test Minio",
+		"driver_type": "s3",
+		"options": {
+			"Bucket": "test-bucket.mycompany.com",
+			"client": {
+				"endpoint": "http://minio:9000",
+				"accessKeyId": "myMinioAccessKey",
+				"secretAccessKey": "myMinioSecretKey",
+				"s3ForcePathStyle": true,
+				"signatureVersion": "v4"
+			}
+		}
+	},
+	"jsonrpc": "2.0",
+	"id": 0
+}
+```
+
+To view the Minio interface to the Buckets containing the vault files, navigate to [http://localhost:9099](http://localhost:9099) when you have the services running.
 
 ##### SFTP
 

--- a/bin/docker_tests
+++ b/bin/docker_tests
@@ -7,7 +7,6 @@ set -e
 # thanks to it we can just enter `./bin/docker_tests`
 cd "${0%/*}/.."
 
-# let's fake failing test for now
 echo "Running tests"
 
 export ROLE=circleci

--- a/compose/circleci.yml
+++ b/compose/circleci.yml
@@ -5,8 +5,11 @@ services:
     image: redis
     expose:
     - '6379'
-    volumes:
-    - /data/shipchain/engine/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli","ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     command: >
       --requirepass redis_pass --appendonly yes
 
@@ -26,6 +29,20 @@ services:
       - '22'
     command: shipchain_user:shipchain_password:::upload
 
+  minio:
+    image: minio/minio
+    command: server /data
+    expose:
+      - "9000"
+    healthcheck:
+      test: "nc -z localhost 9000"
+      timeout: 10s
+      interval: 10s
+      retries: 3
+    environment:
+      MINIO_ACCESS_KEY: myMinioAccessKey
+      MINIO_SECRET_KEY: myMinioSecretKey
+
   psql:
     image: sameersbn/postgresql:9.6-2
     healthcheck:
@@ -40,8 +57,6 @@ services:
     - DB_PASS=engine
     - DB_USER=engine
     - DB_EXTENSION="uuid-ossp"
-    volumes:
-    - /data/shipchain/engine/postgresql:/var/lib/postgresql
 
   rpc:
     extends:
@@ -49,11 +64,17 @@ services:
       file: build.yml
     command: sleep infinity
     links:
+      - redis_db
       - geth-poa
-      - psql
       - sftp
+      - minio
+      - psql
     depends_on:
+      redis_db:
+        condition: service_healthy
       geth-poa:
+        condition: service_healthy
+      minio:
         condition: service_healthy
       psql:
         condition: service_healthy
@@ -67,8 +88,9 @@ services:
       - SFTP_USER=shipchain_user
       - SFTP_PASS=shipchain_password
       - S3_DRIVER_TESTS
-      - S3_BUCKET
-      - AWS_ACCESS_KEY_ID
-      - AWS_SECRET_ACCESS_KEY
+      - S3_BUCKET=my-test-bucket
+      - S3_ENDPOINT=http://minio:9000
+      - S3_ACCESSKEY=myMinioAccessKey
+      - S3_SECRETKEY=myMinioSecretKey
       - LOCAL_SECRET_KEY
       - REDIS_URL

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -5,10 +5,15 @@ services:
     image: redis
     expose:
       - '6379'
-    volumes:
-      - /data/shipchain/engine/redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli","ping"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
     command: >
       --requirepass redis_pass --appendonly yes
+    volumes:
+      - /data/shipchain/engine/redis:/data
 
   geth-poa:
     image: shipchain/geth-poa
@@ -25,10 +30,27 @@ services:
       - GETH_VERBOSITY=1
 
   sftp:
-      image: atmoz/sftp
-      ports:
-          - "2222:22"
-      command: shipchain_user:shipchain_password:::upload
+    image: atmoz/sftp
+    ports:
+        - "2222:22"
+    command: shipchain_user:shipchain_password:::upload
+
+  minio:
+    image: minio/minio
+    command: server /data
+    ports:
+      - "9099:9000"
+    healthcheck:
+      test: "nc -z localhost 9000"
+      timeout: 10s
+      interval: 10s
+      retries: 3
+    volumes:
+    - /data/shipchain/engine/minio:/data
+    - /data/shipchain/engine/minioconfig:/root/.minio
+    environment:
+      MINIO_ACCESS_KEY: myMinioAccessKey
+      MINIO_SECRET_KEY: myMinioSecretKey
 
   psql:
     image: sameersbn/postgresql:9.6-2
@@ -67,9 +89,11 @@ services:
       - sftp
       - redis_db
     depends_on:
-#      redis_db: TODO: Create healthcheck for redis
-#        condition: service_healthy
+      redis_db:
+        condition: service_healthy
       geth-poa:
+        condition: service_healthy
+      minio:
         condition: service_healthy
       psql:
         condition: service_healthy

--- a/src/__tests__/storage.ts
+++ b/src/__tests__/storage.ts
@@ -45,9 +45,12 @@ const SFTP_PORT = process.env.SFTP_PORT || '2222';
 const SFTP_USER = process.env.SFTP_USER || 'shipchain_user';
 const SFTP_PASS = process.env.SFTP_PASS || 'shipchain_password';
 
-// S3 Configuration.  When run with `bin/docker_tests` this pulls environment variables from circleci.yml
-// You need to be authenticated with aws-cli locally before enabling the S3 tests
+// S3 Configuration.  When run with `bin/docker_tests` this pulls environment variables from circleci.yml, or
+// uses defaults for the Minio service started via `bin/dc up sftp`
+const S3_ENDPOINT = process.env.S3_ENDPOINT || 'http://localhost:9099';
 const S3_BUCKET = process.env.S3_BUCKET || 'my-test-bucket';
+const S3_ACCESSKEY = process.env.S3_ACCESSKEY || 'myMinioAccessKey';
+const S3_SECRETKEY = process.env.S3_SECRETKEY || 'myMinioSecretKey';
 
 const epochDirectory = new Date().getTime().toString();
 const utf8HelloWorld = 'Hello, World! Привет мир! 你好，世界！';
@@ -82,6 +85,13 @@ const storageConfigs = {
         root: {
             driver_type: 's3',
             Bucket: S3_BUCKET,
+            client: {
+                endpoint: S3_ENDPOINT,
+                accessKeyId: S3_ACCESSKEY,
+                secretAccessKey: S3_SECRETKEY,
+                s3ForcePathStyle: true,
+                signatureVersion: "v4"
+            },
             base_path: '',
             acl: 'public-read',
             variant: 'root',
@@ -89,6 +99,13 @@ const storageConfigs = {
         sub: {
             driver_type: 's3',
             Bucket: S3_BUCKET,
+            client: {
+                endpoint: S3_ENDPOINT,
+                accessKeyId: S3_ACCESSKEY,
+                secretAccessKey: S3_SECRETKEY,
+                s3ForcePathStyle: true,
+                signatureVersion: "v4"
+            },
             base_path: epochDirectory + '/multi/level',
             acl: 'public-read',
             variant: 'sub',


### PR DESCRIPTION
During local development or standalone installations, if you do not have your own AWS account or do not wish to use your own S3 Buckets for storage you can utilize the provided S3 compatible [Minio](https://www.minio.io/docker.html) service as a storage provider.  This also allows for easier S3 StorageDriver testing as a personal AWS Account/Bucket is no longer required.

To view the Minio interface to the Buckets containing the vault files, navigate to [http://localhost:9099](http://localhost:9099) when you have the services running.

To utilize the Minio service with StorageCredentials, use the following:

```JS
{
  "method": "storage_credentials.create_hosted",
  "params": {
    "title": "Test Minio",
    "driver_type": "s3",
    "options": {
      "Bucket": "test-bucket.mycompany.com",
      "client": {
        "endpoint": "http://minio:9000",
        "accessKeyId": "myMinioAccessKey",
        "secretAccessKey": "myMinioSecretKey",
        "s3ForcePathStyle": true,
        "signatureVersion": "v4"
      }
    }
  },
  "jsonrpc": "2.0",
  "id": 0
}
```