### PR TITLE
Storage Credentials Maintenance Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,8 +327,8 @@ To view the Minio interface to the Buckets containing the vault files, navigate 
       "credentials": {
         "host": "sftp.example.com",
         "port": "22",
-        "username": "my_user",
-        "password": "correcthorsebatterystaple"
+        "username": "rmunroe",
+        "password": "Tr0ub4dor&3"
       }
     }
   },
@@ -345,6 +345,28 @@ List the Title, Driver Type, and Base path of the Storage Credentials hosted in 
 {
   "method": "storage_credentials.list",
   "params": {},
+  "jsonrpc": "2.0",
+  "id": 0
+}
+```
+
+#### Update
+
+Modify the Title or Options of an existing Storage Credentials hosted in Engine.  The `base_path` and `driver_type` of a saved StorageCredentials can not be updated as that change would likely make existing Vaults accessed with the StorageCredentials unreachable.
+
+```JS
+{
+  "method": "storage_credentials.update",
+  "params": {
+    "storageCredentials": "7cc34443-64af-4d48-b9f2-0bcdf488f1e3",
+    "title": "Optional Updated Title",
+    "options": {
+      "credentials": {
+        "username": "rmunroe",
+        "password": "correcthorsebatterystaple"
+      }
+    }
+  },
   "jsonrpc": "2.0",
   "id": 0
 }

--- a/README.md
+++ b/README.md
@@ -350,6 +350,23 @@ List the Title, Driver Type, and Base path of the Storage Credentials hosted in 
 }
 ```
 
+#### Test
+
+After creating a StorageCredential, you may want to test connectivity prior to utilizing it for storing Vaults.  To do this, use the following method with the ID of the created Storage Credential.
+
+```JS
+{
+  "method": "storage_credentials.test",
+  "params": {
+    "storageCredentials": "7cc34443-64af-4d48-b9f2-0bcdf488f1e3"
+  },
+  "jsonrpc": "2.0",
+  "id": 0
+}
+```
+
+The return from this method will include a `"valid": true` if a files was successfully created with the storage driver, or `"valid": false` and potentially a `"message": <reason>` indicating what went wrong.
+
 ### Load Contract
 
 _Documentation in progress..._

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -66,6 +66,7 @@ server.expose("storage_credentials", {
     "create_hosted": RPCStorageCredentials.Create,
     "list": RPCStorageCredentials.List,
     "test": RPCStorageCredentials.TestConnectivity,
+    "update": RPCStorageCredentials.Update,
 });
 
 server.expose("transaction", {

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -59,17 +59,18 @@ server.expose("wallet", {
     "create_hosted": RPCWallet.Create,
     "import_hosted": RPCWallet.Import,
     "list": RPCWallet.List,
-    "balance": RPCWallet.Balance
+    "balance": RPCWallet.Balance,
 });
 
 server.expose("storage_credentials", {
     "create_hosted": RPCStorageCredentials.Create,
-    "list": RPCStorageCredentials.List
+    "list": RPCStorageCredentials.List,
+    "test": RPCStorageCredentials.TestConnectivity,
 });
 
 server.expose("transaction", {
     "sign": RPCTransaction.Sign,
-    "send": RPCTransaction.Send
+    "send": RPCTransaction.Send,
 });
 
 server.expose("load", {
@@ -105,7 +106,7 @@ server.expose("load", {
 
 server.expose("event", {
     "subscribe": RPCEvent.Subscribe,
-    "unsubscribe": RPCEvent.Unsubscribe
+    "unsubscribe": RPCEvent.Unsubscribe,
 });
 
 // Build Schema Validators

--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -131,4 +131,20 @@ export class RPCStorageCredentials {
             message
         };
     }
+
+    @RPCMethod({
+        require: ['storageCredentials'],
+        validate: {
+            uuid: ['storageCredentials'],
+        },
+    })
+    public static async Update(args) {
+        const storage = await StorageCredential.getById(args.storageCredentials);
+
+        await storage.update(args.title, args.options);
+
+        return {
+            updated: true
+        }
+    }
 }

--- a/src/__tests__/credentials.ts
+++ b/src/__tests__/credentials.ts
@@ -55,4 +55,29 @@ describe('StorageCredentialEntity', function() {
 
         expect(credential.getDriverOptions()).toEqual(options_from_id);
     });
+
+    it(`can update storage credentials`, async () => {
+        const attrs = {
+            title: 'My Driver',
+            driver_type: 'local',
+            base_path: './storage/credential-test',
+            options: { foo: 'bar' },
+        };
+
+        const newTitle = "New Title";
+        const newOptions = {setting: "New!"};
+
+        const credential = StorageCredential.generate_entity(attrs);
+        await credential.save();
+
+        // Update Title
+        await credential.update(newTitle);
+        expect(credential.title).toEqual(newTitle);
+        expect(credential.options).toEqual(attrs.options);
+
+        // Update Options
+        await credential.update(null, newOptions);
+        expect(credential.title).toEqual(newTitle);
+        expect(credential.options).toEqual(newOptions);
+    });
 });

--- a/src/entity/StorageCredential.ts
+++ b/src/entity/StorageCredential.ts
@@ -78,7 +78,7 @@ export class StorageCredential extends BaseEntity {
         return count[0]['cnt'];
     }
 
-    static async getOptionsById(id: string) {
+    static async getById(id: string) {
         const DB = getConnection();
         const repository = DB.getRepository(StorageCredential);
 
@@ -88,7 +88,24 @@ export class StorageCredential extends BaseEntity {
             throw new Error('StorageCredentials not found');
         }
 
-        return storageCredential.getDriverOptions();
+        return storageCredential;
+    }
+
+    static async getOptionsById(id: string) {
+        return (await StorageCredential.getById(id)).getDriverOptions();
+    }
+
+    async update(title?: string, options?: any) {
+
+        if(title){
+            this.title = title;
+        }
+
+        if(options){
+            this.options = options;
+        }
+
+        await this.save();
     }
 
     getDriverOptions() {

--- a/src/storage/drivers/S3StorageDriver.ts
+++ b/src/storage/drivers/S3StorageDriver.ts
@@ -71,7 +71,7 @@ export class S3StorageDriver extends StorageDriver {
                         if(err.code == "BucketAlreadyOwnedByYou" || err.code == "BucketAlreadyExists") {
                             resolve(true);
                         } else {
-                            reject(false);
+                            reject(err);
                         }
                     } else {
                         resolve(true);


### PR DESCRIPTION
The Credentials stored within Engine will become outdated as passwords or access keys are updated externally.  There needs to be a method to update existing StorageCredentails with these new values so any Vaults associated can still be accessed.  Additionally, Engine needs to provide a method for testing existing StorageCredentials to ensure they can be utilized for interacting with Vault files.

Two new RPC methods have been added and documentation is included in the README:
 - `storage_credentials.test`
 - `storage_credentials.update`