### PR TITLE
Event Subscriptions and Vault Error Handling Update

### DIFF
--- a/src/__tests__/contracts.ts
+++ b/src/__tests__/contracts.ts
@@ -53,7 +53,7 @@ describe('ContractEntity', function() {
         expect(await Project.count()).toEqual(2);
         expect(await Network.count()).toEqual(3);
         expect(await Version.count()).toEqual(3);
-        expect(await Contract.count()).toEqual(6);
+        expect(await Contract.count()).toEqual(9);
     });
 
     it(

--- a/src/__tests__/storage.ts
+++ b/src/__tests__/storage.ts
@@ -198,7 +198,7 @@ describe('StorageDriver ', function() {
                         caughtError = err;
                     }
 
-                    expect(caughtError.message).toEqual(DriverError.States.NotFoundError);
+                    expect(caughtError.message).toMatch(DriverError.States.NotFoundError);
                 }),
             );
 
@@ -290,7 +290,7 @@ describe('StorageDriver ', function() {
                             caughtError = err;
                         }
 
-                        expect(caughtError.message).toEqual(DriverError.States.NotFoundError);
+                        expect(caughtError.message).toMatch(DriverError.States.NotFoundError);
                     }),
                 );
 
@@ -305,7 +305,7 @@ describe('StorageDriver ', function() {
                             caughtError = err;
                         }
 
-                        expect(caughtError.message).toEqual(DriverError.States.ParameterError);
+                        expect(caughtError.message).toMatch(DriverError.States.ParameterError);
                     }),
                 );
 
@@ -320,7 +320,7 @@ describe('StorageDriver ', function() {
                             caughtError = err;
                         }
 
-                        expect(caughtError.message).toEqual(DriverError.States.ParameterError);
+                        expect(caughtError.message).toMatch(DriverError.States.ParameterError);
                     }),
                 );
 
@@ -335,7 +335,7 @@ describe('StorageDriver ', function() {
                             caughtError = err;
                         }
 
-                        expect(caughtError.message).toEqual(DriverError.States.ParameterError);
+                        expect(caughtError.message).toMatch(DriverError.States.ParameterError);
                     }),
                 );
 
@@ -350,7 +350,7 @@ describe('StorageDriver ', function() {
                             caughtError = err;
                         }
 
-                        expect(caughtError.message).toEqual(DriverError.States.ParameterError);
+                        expect(caughtError.message).toMatch(DriverError.States.ParameterError);
                     }),
                 );
 

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -42,7 +42,11 @@ export class AsyncPoll extends EventEmitter {
 
     static wrapCallback(self: AsyncPoll, callback: any, once?: boolean) {
         async function execute() {
-            await callback();
+            try {
+                await callback();
+            } catch (err) {
+                logger.error(`Error Executing AsyncPoll ${err}`);
+            }
             if (!once) {
                 self.start();
             }

--- a/src/storage/StorageDriver.ts
+++ b/src/storage/StorageDriver.ts
@@ -64,7 +64,7 @@ enum DriverErrorStates {
     NotFoundError = 'File Not Found',
     ParameterError = 'Error in Parameters',
     RequestError = 'Error in Request',
-    UnknownError = 'Unknown Error from Storage Driver',
+    UnknownError = 'Error from Storage Driver',
 }
 
 export class DriverError extends Error {
@@ -77,16 +77,32 @@ export class DriverError extends Error {
     constructor(errorState: DriverErrorStates, wrappedError: Error, reason?: string) {
         super(errorState);
 
+        this.name = 'DriverError';
+
         // Set the prototype explicitly.
         Object.setPrototypeOf(this, DriverError.prototype);
 
         this.errorState = errorState;
         this.wrappedError = wrappedError;
 
-        if (typeof reason == undefined) {
+        if (typeof reason == undefined && wrappedError) {
             this.reason = wrappedError.message;
         } else {
             this.reason = reason;
+        }
+
+        if(wrappedError) {
+            // Cleanup the wrapped error properties to force a better string output when `Error.prototype.toString()` is used
+            if (!wrappedError.name || wrappedError.name === "Error") {
+                wrappedError.name = '';
+            }
+
+            if (!wrappedError.message) {
+                wrappedError.message = '';
+            }
+
+            // Generate the user friendly message
+            this.message = `${errorState} [${wrappedError}]`;
         }
     }
 }


### PR DESCRIPTION
Both Event Subscriptions and Vaults (Storage Drivers) have cases where errors are either not properly caught or are caught but do not produce a helpful message.

ResourceLock methods and AsyncPoll callbacks now have improved error handling.  Additionally, errors from StorageDriver implementations now have a custom error name `DriverError` and include important information from the wrapped error when the prototype `toString()` is invoked.