### PR TITLE
Multiple Project Subscriptions to Single URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,13 +931,14 @@ At any point the subscriber may re-subscribe with the same callback URL and new 
 
 #### Unsubscribe
 
-Remove an existing Event Subscription. The Event Subscription will no longer be restarted when Engine restarts. The only parameter is the URL of an existing Subscription.
+Remove an existing Event Subscription. The Event Subscription will no longer be restarted when Engine restarts. The only parameters are the specific Project and the URL of an existing Subscription.
 
 ```JS
 {
   "method": "event.unsubscribe",
   "params": {
-    "url": "http://transmission.local/api/v1/contract/events/"
+    "url": "http://transmission.local/api/v1/contract/events/",
+    "project": "LOAD"
   },
   "jsonrpc": "2.0",
   "id": 0

--- a/rpc/event.ts
+++ b/rpc/event.ts
@@ -48,9 +48,9 @@ export class RPCEvent {
         };
     }
 
-    @RPCMethod({ require: ['url'] })
+    @RPCMethod({ require: ['url', 'project'] })
     public static async Unsubscribe(args) {
-        const eventSubscription = await EventSubscription.unsubscribe(args.url);
+        const eventSubscription = await EventSubscription.unsubscribe(args.url, args.project);
 
         return {
             success: true,

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -14,7 +14,15 @@
  * limitations under the License.
  */
 
-import { BaseEntity, Column, CreateDateColumn, Entity, getConnection, PrimaryColumn } from 'typeorm';
+import {
+    BaseEntity,
+    Column,
+    CreateDateColumn,
+    Entity,
+    getConnection,
+    Index,
+    PrimaryGeneratedColumn
+} from "typeorm";
 import { Contract } from './Contract';
 import { EventEmitter } from 'events';
 import { Logger, loggers } from 'winston';
@@ -89,8 +97,10 @@ class EventSubscriberAttrs {
 }
 
 @Entity()
+@Index("URL_PROJECT_INDEX", ["url", "project"], { unique: true })
 export class EventSubscription extends BaseEntity {
-    @PrimaryColumn() url: string;
+    @PrimaryGeneratedColumn('uuid') id: string;
+    @Column() url: string;
     @Column() project: string;
     @Column('simple-array') eventNames: string[];
     @Column('bigint') lastBlock: number;

--- a/src/entity/migration/1543335175775-EventSubscriptionUuid.ts
+++ b/src/entity/migration/1543335175775-EventSubscriptionUuid.ts
@@ -1,0 +1,23 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class EventSubscriptionUuid1543335175775 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`ALTER TABLE "event_subscription" ADD "id" uuid NOT NULL DEFAULT uuid_generate_v4()`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" DROP CONSTRAINT "PK_c2a1181e1ab540267b19ee9f7fd"`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" ADD CONSTRAINT "PK_d697322379ee2faa67234d63c52" PRIMARY KEY ("url", "id")`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" DROP CONSTRAINT "PK_d697322379ee2faa67234d63c52"`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" ADD CONSTRAINT "PK_30cfa3a4d386691fef4c5995085" PRIMARY KEY ("id")`);
+        await queryRunner.query(`CREATE UNIQUE INDEX "URL_PROJECT_INDEX" ON "event_subscription"("url", "project") `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+        await queryRunner.query(`DROP INDEX "URL_PROJECT_INDEX"`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" DROP CONSTRAINT "PK_30cfa3a4d386691fef4c5995085"`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" ADD CONSTRAINT "PK_d697322379ee2faa67234d63c52" PRIMARY KEY ("url", "id")`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" DROP CONSTRAINT "PK_d697322379ee2faa67234d63c52"`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" ADD CONSTRAINT "PK_c2a1181e1ab540267b19ee9f7fd" PRIMARY KEY ("url")`);
+        await queryRunner.query(`ALTER TABLE "event_subscription" DROP COLUMN "id"`);
+    }
+
+}


### PR DESCRIPTION
Transmission has the requirement to subscribe to events from multiple contracts (ShipToken and LOAD Contract) with a singular endpoint accepting all messages.  These changes to the EventSubscription model and logic are in support of this requirement.

EventSubscription now has a generated UUID primary column and a unique index on the `project` and `url` fields.  All logic pertaining to ActiveSubscriptions and AsyncPolls has been updated to utilize the new `id` field for property uniqueness after obtaining the record via the combined project and url.

The `event.unsubscribe` RPC method now requires the `project` parameter.

_Note: This contains a database migration which will run automatically the next time your Engine services are started._