### PR TITLE
Document Upload via S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -598,6 +598,26 @@ Adding a file in this container is an overwrite action, not an append, of any co
 }
 ```
 
+##### Add From S3
+
+An alternate approach to adding a file in this container is to request a file be copied from S3 and added to the vault.  This is performed via:
+
+```JS
+{
+  "method": "vault.add_document_from_s3",
+  "params": {
+    "storageCredentials": "a350758d-2dd8-4bab-b983-2390657bbc25",
+    "vaultWallet": "eea40c56-7674-43a5-8612-30abd98cf58b",
+    "vault": "2ed96ba9-26d4-4f26-b3da-c45562268480",
+    "documentName": "example.png",
+    "bucket": "test-bucket.mycompany.com",
+    "key": "2808d10f-2d8c-47c6-9975-8e60fab55bac/7d3e338d-f610-408d-ab1b-0d789725f16d/example.png"
+  },
+  "jsonrpc": "2.0",
+  "id": 0
+}
+```
+
 ##### Retrieve
 
 Retrieving one of the existing documents in this container is performed via:

--- a/README.md
+++ b/README.md
@@ -474,7 +474,6 @@ A vault's contents can be verified against the embedded, signed hash to ensure t
   "method": "vault.verify",
   "params": {
     "storageCredentials": "a350758d-2dd8-4bab-b983-2390657bbc25",
-    "vaultWallet": "eea40c56-7674-43a5-8612-30abd98cf58b",
     "vault": "2ed96ba9-26d4-4f26-b3da-c45562268480"
   },
   "jsonrpc": "2.0",
@@ -626,7 +625,6 @@ Listing the files included in this container is performed via:
   "method": "vault.list_documents",
   "params": {
     "storageCredentials": "a350758d-2dd8-4bab-b983-2390657bbc25",
-    "vaultWallet": "eea40c56-7674-43a5-8612-30abd98cf58b",
     "vault": "2ed96ba9-26d4-4f26-b3da-c45562268480"
   },
   "jsonrpc": "2.0",

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -125,6 +125,7 @@ server.expose("vault", {
     "add_shipment": RPCVault.AddShipmentData,
     "get_document": RPCVault.GetDocument,
     "add_document": RPCVault.AddDocument,
+    "add_document_from_s3": RPCVault.AddDocumentFromS3,
     "list_documents": RPCVault.ListDocuments,
     "verify": RPCVault.VerifyVault,
     "get_historical_shipment_data": RPCVault.GetHistoricalShipmentData,

--- a/rpc/Engine.postman_collection.json
+++ b/rpc/Engine.postman_collection.json
@@ -647,7 +647,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"method\": \"vault.list_documents\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+							"raw": "{\n\t\"method\": \"vault.list_documents\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
 						},
 						"url": {
 							"raw": "http://localhost:2000/",
@@ -675,7 +675,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"method\": \"vault.verify\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+							"raw": "{\n\t\"method\": \"vault.verify\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
 						},
 						"url": {
 							"raw": "http://localhost:2000/",

--- a/rpc/Engine.postman_collection.json
+++ b/rpc/Engine.postman_collection.json
@@ -608,6 +608,34 @@
 					"response": []
 				},
 				{
+					"name": "vault.add_document_from_s3",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"vault.add_document_from_s3\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t    \"documentName\": \"example.png\",\n\t    \"key\": \"2808d10f-2d8c-47c6-9975-8e60fab55bac/7d3e338d-f610-408d-ab1b-0d789725f16d/example.png\",\n\t    \"bucket\": \"test-bucket.mycompany.com\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "http://localhost:2000/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "2000",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "vault.get_document",
 					"request": {
 						"method": "POST",

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -92,7 +92,6 @@ export class RPCVault {
 
         const load = new LoadVault(storage, args.vault);
 
-        await load.getOrCreateMetadata(wallet);
         await load.addTrackingData(wallet, args.payload);
         const signature = await load.writeMetadata(wallet);
 
@@ -137,7 +136,6 @@ export class RPCVault {
 
         const load = new LoadVault(storage, args.vault);
 
-        await load.getOrCreateMetadata(wallet);
         await load.addShipmentData(wallet, args.shipment);
         const signature = await load.writeMetadata(wallet);
 
@@ -180,7 +178,6 @@ export class RPCVault {
 
         const load = new LoadVault(storage, args.vault);
 
-        await load.getOrCreateMetadata(wallet);
         await load.addDocument(wallet, args.documentName, args.documentContent);
         const signature = await load.writeMetadata(wallet);
 
@@ -205,7 +202,6 @@ export class RPCVault {
 
         const load = new LoadVault(storage, args.vault);
 
-        await load.getOrCreateMetadata(wallet);
         await load.addDocument(wallet, args.documentName, documentContent);
         const signature = await load.writeMetadata(wallet);
 
@@ -260,7 +256,6 @@ export class RPCVault {
 
         const load = new LoadVault(storage, args.vault);
 
-        await load.getOrCreateMetadata(wallet);
         const list = await load.listDocuments();
 
         return {
@@ -281,7 +276,6 @@ export class RPCVault {
 
         const load = new LoadVault(storage, args.vault);
 
-        await load.getOrCreateMetadata(wallet);
         const verified = await load.verify();
 
         return {

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -245,14 +245,13 @@ export class RPCVault {
     }
 
     @RPCMethod({
-        require: ['storageCredentials', 'vaultWallet', 'vault'],
+        require: ['storageCredentials', 'vault'],
         validate: {
-            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            uuid: ['storageCredentials', 'vault'],
         },
     })
     public static async ListDocuments(args) {
         const storage = await StorageCredential.getOptionsById(args.storageCredentials);
-        const wallet = await Wallet.getById(args.vaultWallet);
 
         const load = new LoadVault(storage, args.vault);
 
@@ -265,14 +264,13 @@ export class RPCVault {
     }
 
     @RPCMethod({
-        require: ['storageCredentials', 'vaultWallet', 'vault'],
+        require: ['storageCredentials', 'vault'],
         validate: {
-            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            uuid: ['storageCredentials', 'vault'],
         },
     })
     public static async VerifyVault(args) {
         const storage = await StorageCredential.getOptionsById(args.storageCredentials);
-        const wallet = await Wallet.getById(args.vaultWallet);
 
         const load = new LoadVault(storage, args.vault);
 

--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -120,6 +120,8 @@ describe('Vaults', function() {
 
         /* and modifying the signature date invalidates it */
         new_vault.changeSignatureTime();
+        // Override loadMetadata() as we want to force invalid timestamps instead of reloading this from disk.
+        new_vault.loadMetadata = function(): Promise<any> {return new Promise<any>((resolve, reject) => {resolve();});};
         expect(await new_vault.verify()).toBe(false);
 
         /* And delete it to clean up */

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -36,6 +36,7 @@ export class LoadVault extends Vault {
     }
 
     async addTrackingData(author: Wallet, payload) {
+        await this.loadMetadata();
         await this.containers[LoadVault.TRACKING].append(author, payload);
     }
 
@@ -45,6 +46,7 @@ export class LoadVault extends Vault {
     }
 
     async addShipmentData(author: Wallet, shipment) {
+        await this.loadMetadata();
         await this.containers[LoadVault.SHIPMENT].setContents(author, JSON.stringify(shipment));
     }
 
@@ -55,6 +57,7 @@ export class LoadVault extends Vault {
     }
 
     async addDocument(author: Wallet, name: string, document: any) {
+        await this.loadMetadata();
         await this.containers[LoadVault.DOCUMENTS].setSingleContent(author, name, document);
     }
 
@@ -64,6 +67,7 @@ export class LoadVault extends Vault {
     }
 
     async listDocuments() {
+        await this.loadMetadata();
         return await this.containers[LoadVault.DOCUMENTS].listFiles();
     }
 

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -110,6 +110,7 @@ export class Vault {
     }
 
     async verify() {
+        await this.loadMetadata();
         logger.info(`Verifying Vault ${this.id}`);
         for (const name in this.meta.containers) {
             if (this.containers.hasOwnProperty(name)) {


### PR DESCRIPTION
Engine needs to support adding a document to a vault where the content originates in S3.

Part of document management in Transmission will include an upload staging area on S3.  This will enable faster uploads from the clients and easier integration with post-upload workflows.  A new RPC endpoint is being added in Engine to handle pulling the data from the provided Bucket.  This is an RPC-only change and the existing vault/document logic is still being utilized.

Minor changes to the LoadVault have been included as they allow for a more consistent interface to the RPC methods.