### PR TITLE
LoadVault Tracking Container should be an external_list_daily type

### DIFF
--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -29,7 +29,7 @@ export class LoadVault extends Vault {
 
     protected async initializeMetadata(author: Wallet) {
         await super.initializeMetadata(author);
-        this.getOrCreateContainer(author, LoadVault.TRACKING, 'embedded_list');
+        this.getOrCreateContainer(author, LoadVault.TRACKING, 'external_list_daily');
         this.getOrCreateContainer(author, LoadVault.SHIPMENT, 'embedded_file');
         this.getOrCreateContainer(author, LoadVault.DOCUMENTS, 'external_file_multi');
         return this.meta;


### PR DESCRIPTION
This will help prevent the large meta.json files that would occur if we continued using the embedded_list type.

Additionally, this will help prevent performance degradation if a large amount of tracking data was added (every subsequent addition adds to the append time due to decryption/encryption of more data)