### PR TITLE
Web3 Timing Metrics

### DIFF
--- a/src/MetricsReporter.ts
+++ b/src/MetricsReporter.ts
@@ -70,7 +70,7 @@ export class MetricsReporter {
     }
 
     public methodTime(method: string, time_delta: number, tags: any = {}) {
-        const point = MetricsReporter.buildPoint(Object.assign({ method: method }, tags), {time: time_delta});
+        const point = MetricsReporter.buildPoint(Object.assign({ method: method }, tags), {time_delta: time_delta});
 
         this.report('engine.method_time', point);
     }

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -27,10 +27,12 @@ import { Contract } from './Contract';
 import { EventEmitter } from 'events';
 import { Logger, loggers } from 'winston';
 import { getRequestOptions } from '../request-options';
+import { MetricsReporter } from "../MetricsReporter";
 
 const request = require('request');
 
 const logger: Logger = loggers.get('engine');
+const metrics = MetricsReporter.Instance;
 
 const SECONDS = 1000;
 
@@ -261,6 +263,7 @@ export class EventSubscription extends BaseEntity {
                         eventSubscription.lastBlock ? +eventSubscription.lastBlock + 1 : 0
                     }`,
                 );
+                const startTime = Date.now();
                 eventSubscription.contractDriver.getPastEvents(
                     eventName,
                     {
@@ -274,6 +277,7 @@ export class EventSubscription extends BaseEntity {
                         }
                         else {
                             if (events.length) {
+                                metrics.methodTime('getPastEvents', Date.now() - startTime,{eventName: eventName, web3: true});
                                 logger.info(`Found ${events.length} Events`);
                                 let highestBlock = EventSubscription.findHighestBlockInEvents(
                                     events,


### PR DESCRIPTION
Engine should report metrics on Web3 interactions to allow for easy monitoring of the connection to the ethereum node.

Additionally, this fixes a bug in `methodTime` where the reserved word `time` was used.  This prevented the timing data from being used in ShipChain's existing Grafana dashboards.