### PR TITLE
Storage Credential Directory and Vault Deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "redlock": "^3.1.2",
     "request": "^2.34",
     "request-promise-native": "^1.0.5",
+    "rimraf": "^2.6.2",
     "sql.js": "^0.5.0",
     "sqlite3": "^4.0.4",
     "ssh2-sftp-client": "^2.4.2",

--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -103,7 +103,7 @@ export class RPCStorageCredentials {
                 throw new Error("Stored content does not match retrieved content");
             }
 
-            await driver.removeFile(testFileName);
+            await driver.removeDirectory(null, true);
 
             valid = true;
         }

--- a/src/__tests__/storage.ts
+++ b/src/__tests__/storage.ts
@@ -361,6 +361,35 @@ describe('StorageDriver ', function() {
                         expect(result).toBeUndefined();
                     }),
                 );
+
+                it(
+                    `throws when deleting a non-empty ${fileConfig.variant} ${fileConfig.type} directory`,
+                    mochaAsync(async () => {
+                        let caughtError;
+
+                        let result = await storageDriver.putFile(fileConfig.file, fileConfig.data, fileConfig.binary);
+                        expect(result).toBeUndefined();
+
+                        try {
+                            await storageDriver.removeDirectory(null, false);
+                        } catch (err) {
+                            caughtError = err;
+                        }
+
+                        expect(caughtError.message).toMatch(DriverError.States.RequestError);
+                    }),
+                );
+
+                it(
+                    `does not throws when recursively deleting a non-empty ${fileConfig.variant} ${fileConfig.type} directory`,
+                    mochaAsync(async () => {
+                        let result = await storageDriver.putFile(fileConfig.file, fileConfig.data, fileConfig.binary);
+                        expect(result).toBeUndefined();
+
+                        result = await storageDriver.removeDirectory(null, true);
+                        expect(result).toBeUndefined();
+                    }),
+                );
             });
         });
     });

--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -92,7 +92,7 @@ describe('Vaults', function() {
         expect(await vault.metadataFileExists()).toBe(true);
 
         /* And delete it to clean up */
-        await vault.deleteMetadata();
+        await vault.deleteEverything();
         expect(await vault.metadataFileExists()).toBe(false);
     });
 
@@ -125,7 +125,7 @@ describe('Vaults', function() {
         expect(await new_vault.verify()).toBe(false);
 
         /* And delete it to clean up */
-        await vault.deleteMetadata();
+        await vault.deleteEverything();
         expect(await vault.metadataFileExists()).toBe(false);
     });
 
@@ -165,7 +165,7 @@ describe('Vaults', function() {
         expect(await vault.decryptMessage(stranger, encrypted)).toBe('TeST');
 
         /* And delete it to clean up */
-        await vault.deleteMetadata();
+        await vault.deleteEverything();
         expect(await vault.metadataFileExists()).toBe(false);
     });
 
@@ -271,7 +271,7 @@ describe('Vaults', function() {
         expect(await container.decryptContents(author)).toBe('TEST EMBED');
 
         /* And delete it to clean up */
-        await vault.deleteMetadata();
+        await vault.deleteEverything();
         expect(await vault.metadataFileExists()).toBe(false);
     });
 
@@ -316,7 +316,7 @@ describe('Vaults', function() {
         expect(await container.decryptContents(author)).toBe('TEST External');
 
         /* And delete it to clean up */
-        await vault.deleteMetadata();
+        await vault.deleteEverything();
         expect(await vault.metadataFileExists()).toBe(false);
     });
 
@@ -349,7 +349,7 @@ describe('Vaults', function() {
         expect(await container.decryptContents(author, 'file_02.txt')).toBe('TEST External 2');
 
         /* And delete it to clean up */
-        await vault.deleteMetadata();
+        await vault.deleteEverything();
         expect(await vault.metadataFileExists()).toBe(false);
     });
 

--- a/src/shipchain/__tests__/loadvault.ts
+++ b/src/shipchain/__tests__/loadvault.ts
@@ -73,7 +73,7 @@ describe('LoadVault', function() {
         expect(await vault.metadataFileExists()).toBe(true);
 
         /* And delete it to clean up */
-        await vault.deleteMetadata();
+        await vault.deleteEverything();
         expect(await vault.metadataFileExists()).toBe(false);
     });
 

--- a/src/storage/StorageDriver.ts
+++ b/src/storage/StorageDriver.ts
@@ -30,8 +30,11 @@ export abstract class StorageDriver {
         this.type = type;
     }
 
-    protected getFullVaultPath(relativeFilePath: string) {
+    protected getFullVaultPath(relativeFilePath: string, allowOnlyBasePath?: boolean) {
         if (!relativeFilePath) {
+            if (allowOnlyBasePath) {
+                return this.base_path;
+            }
             throw new DriverError(DriverError.States.ParameterError, null, 'Missing filename from request');
         }
 
@@ -52,6 +55,8 @@ export abstract class StorageDriver {
     abstract async putFile(filePath: string, data: any, binary?: boolean): Promise<any>;
 
     abstract async removeFile(filePath: string): Promise<any>;
+
+    abstract async removeDirectory(directoryPath: string, recursive?: boolean): Promise<any>;
 
     abstract async fileExists(filePath: string): Promise<any>;
 
@@ -103,6 +108,8 @@ export class DriverError extends Error {
 
             // Generate the user friendly message
             this.message = `${errorState} [${wrappedError}]`;
+        } else {
+            this.message = `${errorState} [${this.reason}]`
         }
     }
 }

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -276,9 +276,8 @@ export class Vault {
         return this.meta.signed;
     }
 
-    async deleteMetadata() {
-        logger.info(`Deleting Vault ${this.id}`);
-        return await this.removeFile(Vault.METADATA_FILE_NAME);
+    async deleteEverything() {
+        await this.removeDirectory(null, true);
     }
 
     async updateContainerMetadata(author: Wallet) {
@@ -305,6 +304,10 @@ export class Vault {
 
     async removeFile(filePath: string) {
         return await ResourceLock(this.id, this.driver, "removeFile", [filePath]);
+    }
+
+    async removeDirectory(directoryPath: string, recursive?: boolean) {
+        return await ResourceLock(this.id, this.driver, "removeDirectory", [directoryPath, recursive]);
     }
 
     async listDirectory(vaultDirectory: string, recursive?: boolean) {


### PR DESCRIPTION
Engine tests a StorageCredential by creating directories and files, but it is currently unable to delete the directories.  This adds support for deleting directories from a storage driver.

For now, the Vault Deletion is not exposed via RPC, but it is utilized in Vault unit tests to keep the working directory cleaner.