### PR TITLE
CircleCI Docker Image Build: Cache -> Workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,10 +59,10 @@ jobs:
           command: |
             mkdir -p docker-cache
             docker save -o docker-cache/built-image.tar engine-node
-      - save_cache:
-          key: docker-cache-{{ .Branch }}-{{ .Revision }}
+      - persist_to_workspace:
+          root: docker-cache
           paths:
-            - docker-cache
+            - built-image.tar
   push-to-ecr:
     docker:
       - image: docker:stable-git


### PR DESCRIPTION
Switch from using CircleCI Caching to Workspaces; the intended use of the circleci 'cache' is for cross-workflow caching - we only need to our built docker image between jobs in a given workflow, so workspaces are more appropriate: https://circleci.com/blog/deep-diving-into-circleci-workspaces/