### PR TITLE
StorageDriver Pre-Validation and Context

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ To view the Minio interface to the Buckets containing the vault files, navigate 
 {
   "method": "storage_credentials.create_hosted",
   "params": {
-    "driver_type": "sfstp",
+    "driver_type": "sftp",
     "title": "My SFTP Server",
     "base_path": "vaults",
     "options": {
@@ -391,6 +391,23 @@ To view the Minio interface to the Buckets containing the vault files, navigate 
         "password": "Tr0ub4dor&3"
       }
     }
+  },
+  "jsonrpc": "2.0",
+  "id": 0
+}
+```
+
+#### Validate and Create
+
+Engine also provides the ability to Validate Storage Credential options prior to creating the entity.  This is useful for testing permissions, base path, authentication, etc without needing to create the entity first and then call a separate rpc method to test.  If the connectivity test is performed successfully, the entity will be created.  If the test fails, the entity is not created and the error response will contain information regarding the failure.
+
+The arguments to this endpoint are identical to those in the `"method": "storage_credentials.create_hosted"` method.   The only difference in invoking this endpoint is the method name.
+
+```JS
+{
+  "method": "storage_credentials.validate_create",
+  "params": {
+    ...
   },
   "jsonrpc": "2.0",
   "id": 0

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -63,6 +63,7 @@ server.expose("wallet", {
 
 server.expose("storage_credentials", {
     "create_hosted": RPCStorageCredentials.Create,
+    "validate_create": RPCStorageCredentials.TestAndStore,
     "list": RPCStorageCredentials.List,
     "test": RPCStorageCredentials.TestConnectivity,
     "update": RPCStorageCredentials.Update,

--- a/rpc/Engine.postman_collection.json
+++ b/rpc/Engine.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "66be1186-0160-46f1-ac3d-f0e4d14ed896",
+		"_postman_id": "8ce470f7-0a00-4a21-883c-8cf5000b7302",
 		"name": "Engine",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -218,6 +218,34 @@
 					"response": []
 				},
 				{
+					"name": "storage_credentials.validate_create (S3)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"storage_credentials.validate_create\",\n\t\"params\": {\n\t\t\"title\": \"Test S3\",\n\t\t\"driver_type\": \"s3\",\n\t\t\"options\": {\n\t\t\t\"Bucket\": \"test-bucket.mycompany.com\"\n\t\t}\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "http://localhost:2000/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "2000",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "storage_credentials.create_hosted (SFTP)",
 					"request": {
 						"method": "POST",
@@ -246,6 +274,34 @@
 					"response": []
 				},
 				{
+					"name": "storage_credentials.validate_create (SFTP)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"storage_credentials.validate_create\",\n\t\"params\": {\n\t\t\"title\": \"Test SFTP\",\n\t\t\"driver_type\": \"sftp\",\n\t\t\"options\": {\n\t\t\t\"credentials\": {\n\t\t\t\t\"host\": \"localhost\",\n\t\t\t\t\"port\": \"22\",\n\t\t\t\t\"username\": \"xkcd\",\n\t\t\t\t\"password\": \"Tr0ub4dor&3\"\n\t\t\t}\n\t\t}\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "http://localhost:2000/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "2000",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
 					"name": "storage_credentials.create_hosted (Local)",
 					"request": {
 						"method": "POST",
@@ -258,6 +314,34 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n\t\"method\": \"storage_credentials.create_hosted\",\n\t\"params\": {\n\t\t\"title\": \"Test Local\",\n\t\t\"driver_type\": \"local\",\n\t\t\"base_path\": \"ngin_vaults\",\n\t\t\"options\": {}\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "http://localhost:2000/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "2000",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "storage_credentials.validate_create (Local)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"storage_credentials.validate_create\",\n\t\"params\": {\n\t\t\"title\": \"Test Local\",\n\t\t\"driver_type\": \"local\",\n\t\t\"base_path\": \"ngin_vaults\",\n\t\t\"options\": {}\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
 						},
 						"url": {
 							"raw": "http://localhost:2000/",

--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -28,7 +28,6 @@ const driverType = ['s3', 'sftp', 'local'];
 
 @RPCNamespace({ name: 'StorageCredentials' })
 export class RPCStorageCredentials {
-
     private static async _create(args) {
         const credentials = StorageCredential.generate_entity(args);
 
@@ -73,7 +72,7 @@ export class RPCStorageCredentials {
         };
     }
 
-    private static async _test_credentials(credentials: any): Promise<{valid: boolean, message: string}> {
+    private static async _test_credentials(credentials: any): Promise<{ valid: boolean; message: string }> {
         const testDirectory = `TestConnectivity_${new Date().getTime()}`;
         const testFileName = 'TestConnectivity.txt';
         const testContent = 'Hello, World! Привет мир! 你好，世界！';
@@ -142,10 +141,10 @@ export class RPCStorageCredentials {
         const testOptions = await credentials.getDriverOptions();
         const testResults = await RPCStorageCredentials._test_credentials(testOptions);
 
-        if(testResults.valid){
+        if (testResults.valid) {
             return {
                 ...testResults,
-                ...await RPCStorageCredentials._create(args),
+                ...(await RPCStorageCredentials._create(args)),
             };
         } else {
             return testResults;

--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -113,14 +113,6 @@ export class RPCStorageCredentials {
             } else {
                 message = err;
             }
-
-            if (err.wrappedError) {
-                if (err.wrappedError.message) {
-                    message = message + '. ' + err.wrappedError.message;
-                } else {
-                    message = message + '. ' + err.wrappedError;
-                }
-            }
         }
 
         return {

--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -28,14 +28,8 @@ const driverType = ['s3', 'sftp', 'local'];
 
 @RPCNamespace({ name: 'StorageCredentials' })
 export class RPCStorageCredentials {
-    @RPCMethod({ require: ['title', 'driver_type'] })
-    public static async Create(args) {
-        // Local driver type is disabled in environment other than LOCAL
-        // and storage credentials creation is disabled for unrecognizable driver type
-        if ((ENV != 'LOCAL' && args.driver_type === 'local') || driverType.indexOf(args.driver_type) < 0) {
-            throw new Error(`Driver type: ${args.driver_type}, not allowed!`);
-        }
 
+    private static async _create(args) {
         const credentials = StorageCredential.generate_entity(args);
 
         await credentials.save();
@@ -58,6 +52,17 @@ export class RPCStorageCredentials {
         };
     }
 
+    @RPCMethod({ require: ['title', 'driver_type'] })
+    public static async Create(args) {
+        // Local driver type is disabled in environment other than LOCAL
+        // and storage credentials creation is disabled for unrecognizable driver type
+        if ((ENV != 'LOCAL' && args.driver_type === 'local') || driverType.indexOf(args.driver_type) < 0) {
+            throw new Error(`Driver type: ${args.driver_type}, not allowed!`);
+        }
+
+        return await RPCStorageCredentials._create(args);
+    }
+
     @RPCMethod()
     public static async List() {
         const storageCredentials: StorageCredential[] = await StorageCredential.listAll();
@@ -68,13 +73,7 @@ export class RPCStorageCredentials {
         };
     }
 
-    @RPCMethod({
-        require: ['storageCredentials'],
-        validate: {
-            uuid: ['storageCredentials'],
-        },
-    })
-    public static async TestConnectivity(args) {
+    private static async _test_credentials(credentials: any): Promise<{valid: boolean, message: string}> {
         const testDirectory = `TestConnectivity_${new Date().getTime()}`;
         const testFileName = 'TestConnectivity.txt';
         const testContent = 'Hello, World! Привет мир! 你好，世界！';
@@ -83,11 +82,9 @@ export class RPCStorageCredentials {
         let message: string = undefined;
 
         try {
-            const testOptions = await StorageCredential.getOptionsById(args.storageCredentials);
-
             const auth = {
-                ...testOptions,
-                base_path: path.join(testOptions.base_path || './', testDirectory),
+                ...credentials,
+                base_path: path.join(credentials.base_path || './', testDirectory),
             };
 
             const driver = StorageDriverFactory.create(auth);
@@ -119,6 +116,40 @@ export class RPCStorageCredentials {
             valid: valid,
             message,
         };
+    }
+
+    @RPCMethod({
+        require: ['storageCredentials'],
+        validate: {
+            uuid: ['storageCredentials'],
+        },
+    })
+    public static async TestConnectivity(args) {
+        const testOptions = await StorageCredential.getOptionsById(args.storageCredentials);
+        return await RPCStorageCredentials._test_credentials(testOptions);
+    }
+
+    @RPCMethod({ require: ['title', 'driver_type'] })
+    public static async TestAndStore(args) {
+        // Local driver type is disabled in environment other than LOCAL
+        // and storage credentials creation is disabled for unrecognizable driver type
+        if ((ENV != 'LOCAL' && args.driver_type === 'local') || driverType.indexOf(args.driver_type) < 0) {
+            throw new Error(`Driver type: ${args.driver_type}, not allowed!`);
+        }
+
+        const credentials = StorageCredential.generate_entity(args);
+
+        const testOptions = await credentials.getDriverOptions();
+        const testResults = await RPCStorageCredentials._test_credentials(testOptions);
+
+        if(testResults.valid){
+            return {
+                ...testResults,
+                ...await RPCStorageCredentials._create(args),
+            };
+        } else {
+            return testResults;
+        }
     }
 
     @RPCMethod({

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -221,7 +221,7 @@ export class RPCVault {
                 },
                 (err, data) => {
                     if (err) {
-                        reject(new DriverError(DriverError.States.NotFoundError, err));
+                        reject(new DriverError("S3 Read File", DriverError.States.NotFoundError, err));
                     } else {
                         let document;
 

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -221,7 +221,7 @@ export class RPCVault {
                 },
                 (err, data) => {
                     if (err) {
-                        reject(new DriverError("S3 Read File", DriverError.States.NotFoundError, err));
+                        reject(new DriverError('S3 Read File', DriverError.States.NotFoundError, err));
                     } else {
                         let document;
 

--- a/src/storage/StorageDriver.ts
+++ b/src/storage/StorageDriver.ts
@@ -30,12 +30,16 @@ export abstract class StorageDriver {
         this.type = type;
     }
 
+    protected getContext(action: string): string {
+        return `${this.type.toUpperCase()} ${action}`;
+    }
+
     protected getFullVaultPath(relativeFilePath: string, allowOnlyBasePath?: boolean) {
         if (!relativeFilePath) {
             if (allowOnlyBasePath) {
                 return this.base_path;
             }
-            throw new DriverError(DriverError.States.ParameterError, null, 'Missing filename from request');
+            throw new DriverError(this.getContext('Get Vault Path'), DriverError.States.ParameterError, null, 'Missing filename from request');
         }
 
         if (this.base_path) {
@@ -79,7 +83,7 @@ export class DriverError extends Error {
     wrappedError: Error;
     reason: string;
 
-    constructor(errorState: DriverErrorStates, wrappedError: Error, reason?: string) {
+    constructor(context: string, errorState: DriverErrorStates, wrappedError: Error, reason?: string) {
         super(errorState);
 
         this.name = 'DriverError';
@@ -107,9 +111,9 @@ export class DriverError extends Error {
             }
 
             // Generate the user friendly message
-            this.message = `${errorState} [${wrappedError}]`;
+            this.message = `${context}: ${errorState} [${wrappedError}]`;
         } else {
-            this.message = `${errorState} [${this.reason}]`;
+            this.message = `${context}: ${errorState} [${this.reason}]`;
         }
     }
 }

--- a/src/storage/StorageDriver.ts
+++ b/src/storage/StorageDriver.ts
@@ -39,7 +39,12 @@ export abstract class StorageDriver {
             if (allowOnlyBasePath) {
                 return this.base_path;
             }
-            throw new DriverError(this.getContext('Get Vault Path'), DriverError.States.ParameterError, null, 'Missing filename from request');
+            throw new DriverError(
+                this.getContext('Get Vault Path'),
+                DriverError.States.ParameterError,
+                null,
+                'Missing filename from request',
+            );
         }
 
         if (this.base_path) {

--- a/src/storage/drivers/LocalStorageDriver.ts
+++ b/src/storage/drivers/LocalStorageDriver.ts
@@ -77,7 +77,12 @@ export class LocalStorageDriver extends StorageDriver {
         let encoding = binary ? null : 'utf8';
 
         if (!data) {
-            throw new DriverError(this.getContext('Write File'), DriverError.States.ParameterError, null, 'Missing file content');
+            throw new DriverError(
+                this.getContext('Write File'),
+                DriverError.States.ParameterError,
+                null,
+                'Missing file content',
+            );
         }
 
         await this._validateDirectoryPath(filePath);
@@ -160,9 +165,13 @@ export class LocalStorageDriver extends StorageDriver {
                     if (!vaultDirectory && err.code == 'ENOENT') {
                         resolve(new DirectoryListing('.'));
                     } else if (vaultDirectory && err.code == 'ENOENT') {
-                        reject(new DriverError(this.getContext('List Directory'), DriverError.States.NotFoundError, err));
+                        reject(
+                            new DriverError(this.getContext('List Directory'), DriverError.States.NotFoundError, err),
+                        );
                     } else {
-                        reject(new DriverError(this.getContext('List Directory'), DriverError.States.RequestError, err));
+                        reject(
+                            new DriverError(this.getContext('List Directory'), DriverError.States.RequestError, err),
+                        );
                     }
                 } else {
                     let directoryListing = new DirectoryListing(directoryRelativeName);
@@ -175,7 +184,13 @@ export class LocalStorageDriver extends StorageDriver {
                         try {
                             itemIsFile = await this.checkIfFile(fileInVaultPath);
                         } catch (err) {
-                            reject(new DriverError(this.getContext('List Directory'), DriverError.States.UnknownError, err));
+                            reject(
+                                new DriverError(
+                                    this.getContext('List Directory'),
+                                    DriverError.States.UnknownError,
+                                    err,
+                                ),
+                            );
                         }
 
                         if (itemIsFile) {
@@ -186,7 +201,13 @@ export class LocalStorageDriver extends StorageDriver {
                                 try {
                                     subDirListing = await this._listDirectoryImplementation(fileInVaultPath, recursive);
                                 } catch (err) {
-                                    reject(new DriverError(this.getContext('List Directory'), DriverError.States.UnknownError, err));
+                                    reject(
+                                        new DriverError(
+                                            this.getContext('List Directory'),
+                                            DriverError.States.UnknownError,
+                                            err,
+                                        ),
+                                    );
                                 }
                                 directoryListing.addDirectory(subDirListing);
                             } else {

--- a/src/storage/drivers/LocalStorageDriver.ts
+++ b/src/storage/drivers/LocalStorageDriver.ts
@@ -45,7 +45,7 @@ export class LocalStorageDriver extends StorageDriver {
                     if (err.code === 'ENOENT') {
                         resolve(false);
                     } else {
-                        reject(new DriverError(DriverError.States.RequestError, err));
+                        reject(new DriverError(this.getContext('File Exist'), DriverError.States.RequestError, err));
                     }
                 } else {
                     resolve(stats.isFile());
@@ -62,7 +62,7 @@ export class LocalStorageDriver extends StorageDriver {
             fs.readFile(this.getFullVaultPath(filePath), encoding, (err, data) => {
                 if (err) {
                     metrics.methodTime('storage_get_file', Date.now() - startTime, { driver_type: this.type });
-                    reject(new DriverError(DriverError.States.NotFoundError, err));
+                    reject(new DriverError(this.getContext('Read File'), DriverError.States.NotFoundError, err));
                 } else {
                     metrics.methodTime('storage_get_file', Date.now() - startTime, { driver_type: this.type });
                     resolve(data);
@@ -77,7 +77,7 @@ export class LocalStorageDriver extends StorageDriver {
         let encoding = binary ? null : 'utf8';
 
         if (!data) {
-            throw new DriverError(DriverError.States.ParameterError, null, 'Missing file content');
+            throw new DriverError(this.getContext('Write File'), DriverError.States.ParameterError, null, 'Missing file content');
         }
 
         await this._validateDirectoryPath(filePath);
@@ -86,7 +86,7 @@ export class LocalStorageDriver extends StorageDriver {
             fs.writeFile(this.getFullVaultPath(filePath), data, encoding, (err, data) => {
                 if (err) {
                     metrics.methodTime('storage_put_file', Date.now() - startTime, { driver_type: this.type });
-                    reject(new DriverError(DriverError.States.RequestError, err));
+                    reject(new DriverError(this.getContext('Write File'), DriverError.States.RequestError, err));
                 } else {
                     metrics.methodTime('storage_put_file', Date.now() - startTime, { driver_type: this.type });
                     resolve();
@@ -106,7 +106,7 @@ export class LocalStorageDriver extends StorageDriver {
                         resolve();
                     } else {
                         metrics.methodTime('storage_remove_file', Date.now() - startTime, { driver_type: this.type });
-                        reject(new DriverError(DriverError.States.RequestError, err));
+                        reject(new DriverError(this.getContext('Delete File'), DriverError.States.RequestError, err));
                     }
                 } else {
                     metrics.methodTime('storage_remove_file', Date.now() - startTime, { driver_type: this.type });
@@ -131,7 +131,7 @@ export class LocalStorageDriver extends StorageDriver {
             rmdirMethod(fullVaultPath, (err, data) => {
                 if (err) {
                     metrics.methodTime('storage_remove_directory', Date.now() - startTime, { driver_type: this.type });
-                    reject(new DriverError(DriverError.States.RequestError, err));
+                    reject(new DriverError(this.getContext('Remove Directory'), DriverError.States.RequestError, err));
                 } else {
                     metrics.methodTime('storage_remove_directory', Date.now() - startTime, { driver_type: this.type });
                     resolve();
@@ -160,9 +160,9 @@ export class LocalStorageDriver extends StorageDriver {
                     if (!vaultDirectory && err.code == 'ENOENT') {
                         resolve(new DirectoryListing('.'));
                     } else if (vaultDirectory && err.code == 'ENOENT') {
-                        reject(new DriverError(DriverError.States.NotFoundError, err));
+                        reject(new DriverError(this.getContext('List Directory'), DriverError.States.NotFoundError, err));
                     } else {
-                        reject(new DriverError(DriverError.States.RequestError, err));
+                        reject(new DriverError(this.getContext('List Directory'), DriverError.States.RequestError, err));
                     }
                 } else {
                     let directoryListing = new DirectoryListing(directoryRelativeName);
@@ -175,7 +175,7 @@ export class LocalStorageDriver extends StorageDriver {
                         try {
                             itemIsFile = await this.checkIfFile(fileInVaultPath);
                         } catch (err) {
-                            reject(new DriverError(DriverError.States.UnknownError, err));
+                            reject(new DriverError(this.getContext('List Directory'), DriverError.States.UnknownError, err));
                         }
 
                         if (itemIsFile) {
@@ -186,7 +186,7 @@ export class LocalStorageDriver extends StorageDriver {
                                 try {
                                     subDirListing = await this._listDirectoryImplementation(fileInVaultPath, recursive);
                                 } catch (err) {
-                                    reject(new DriverError(DriverError.States.UnknownError, err));
+                                    reject(new DriverError(this.getContext('List Directory'), DriverError.States.UnknownError, err));
                                 }
                                 directoryListing.addDirectory(subDirListing);
                             } else {

--- a/src/storage/drivers/S3StorageDriver.ts
+++ b/src/storage/drivers/S3StorageDriver.ts
@@ -39,6 +39,7 @@ export class S3StorageDriver extends StorageDriver {
 
         if (!config.hasOwnProperty('Bucket') || typeof config.Bucket == undefined) {
             throw new DriverError(
+                this.getContext('Configuration'),
                 DriverError.States.ConfigurationError,
                 null,
                 "Required 'Bucket' configuration missing",
@@ -55,7 +56,7 @@ export class S3StorageDriver extends StorageDriver {
         try {
             this.s3 = new S3(s3_options);
         } catch (err) {
-            throw new DriverError(DriverError.States.ConnectionError, err);
+            throw new DriverError(this.getContext('Configuration'), DriverError.States.ConnectionError, err);
         }
     }
 
@@ -88,7 +89,7 @@ export class S3StorageDriver extends StorageDriver {
                 },
                 (err, data) => {
                     if (err) {
-                        reject(new DriverError(DriverError.States.RequestError, err));
+                        reject(new DriverError(this.getContext('List Bucket'), DriverError.States.RequestError, err));
                     } else {
                         resolve(true);
                     }
@@ -112,7 +113,7 @@ export class S3StorageDriver extends StorageDriver {
                     if (err) {
                         metrics.methodTime('storage_get_file', Date.now() - startTime, { driver_type: this.type });
 
-                        reject(new DriverError(DriverError.States.NotFoundError, err));
+                        reject(new DriverError(this.getContext('Read File'), DriverError.States.NotFoundError, err));
                     } else {
                         let fileContent = data.Body;
                         if (!binary) {
@@ -147,7 +148,7 @@ export class S3StorageDriver extends StorageDriver {
                         if (err) {
                             metrics.methodTime('storage_put_file', Date.now() - startTime, { driver_type: this.type });
 
-                            reject(new DriverError(DriverError.States.RequestError, err));
+                            reject(new DriverError(this.getContext('Write File'), DriverError.States.RequestError, err));
                         } else {
                             metrics.methodTime('storage_put_file', Date.now() - startTime, { driver_type: this.type });
 
@@ -158,7 +159,7 @@ export class S3StorageDriver extends StorageDriver {
             } catch (err) {
                 metrics.methodTime('storage_put_file', Date.now() - startTime, { driver_type: this.type });
 
-                reject(new DriverError(DriverError.States.ParameterError, err));
+                reject(new DriverError(this.getContext('Write File'), DriverError.States.ParameterError, err));
             }
         });
     }
@@ -187,7 +188,7 @@ export class S3StorageDriver extends StorageDriver {
                                 driver_type: this.type,
                             });
 
-                            reject(new DriverError(DriverError.States.UnknownError, err));
+                            reject(new DriverError(this.getContext('Delete File'), DriverError.States.UnknownError, err));
                         }
                     } else {
                         metrics.methodTime('storage_remove_file', Date.now() - startTime, { driver_type: this.type });
@@ -211,7 +212,7 @@ export class S3StorageDriver extends StorageDriver {
 
         if (listedObjects.Contents.length === 0) return;
 
-        if (!recursive) throw new DriverError(DriverError.States.RequestError, null, 'Directory not empty');
+        if (!recursive) throw new DriverError(this.getContext('Remove Directory'), DriverError.States.RequestError, null, 'Directory not empty');
 
         const deleteParams = {
             Bucket: this.bucket,
@@ -251,7 +252,7 @@ export class S3StorageDriver extends StorageDriver {
                                 driver_type: this.type,
                             });
 
-                            reject(new DriverError(DriverError.States.UnknownError, err));
+                            reject(new DriverError(this.getContext('Head Object'), DriverError.States.UnknownError, err));
                         }
                     } else {
                         if (data.DeleteMarker) {
@@ -295,9 +296,9 @@ export class S3StorageDriver extends StorageDriver {
                     if (!vaultDirectory && (err.code == 'NoSuchKey' || err.code == 'NoSuchBucket')) {
                         resolve(new DirectoryListing('.'));
                     } else if (vaultDirectory && err.code == 'NoSuchKey') {
-                        reject(new DriverError(DriverError.States.NotFoundError, err));
+                        reject(new DriverError(this.getContext('List Objects'), DriverError.States.NotFoundError, err));
                     } else {
-                        reject(new DriverError(DriverError.States.RequestError, err));
+                        reject(new DriverError(this.getContext('List Objects'), DriverError.States.RequestError, err));
                     }
                 } else {
                     let directoryListing = new DirectoryListing(directoryRelativeName);
@@ -321,7 +322,7 @@ export class S3StorageDriver extends StorageDriver {
                             try {
                                 subDirListing = await this._listDirectoryImplementation(subPrefix, recursive);
                             } catch (err) {
-                                reject(new DriverError(DriverError.States.UnknownError, err));
+                                reject(new DriverError(this.getContext('List Objects'), DriverError.States.UnknownError, err));
                             }
 
                             directoryListing.addDirectory(subDirListing);
@@ -360,7 +361,7 @@ export class S3StorageDriver extends StorageDriver {
         if (vaultSearchPath) {
             if (!(await this.fileExists(vaultSearchPath))) {
                 metrics.methodTime('storage_list_directory', Date.now() - startTime, { driver_type: this.type });
-                throw new DriverError(DriverError.States.NotFoundError, null);
+                throw new DriverError(this.getContext('List Directory'), DriverError.States.NotFoundError, null);
             }
 
             vaultSearchPath = path.join(this.base_path, vaultSearchPath);

--- a/src/storage/drivers/S3StorageDriver.ts
+++ b/src/storage/drivers/S3StorageDriver.ts
@@ -148,7 +148,9 @@ export class S3StorageDriver extends StorageDriver {
                         if (err) {
                             metrics.methodTime('storage_put_file', Date.now() - startTime, { driver_type: this.type });
 
-                            reject(new DriverError(this.getContext('Write File'), DriverError.States.RequestError, err));
+                            reject(
+                                new DriverError(this.getContext('Write File'), DriverError.States.RequestError, err),
+                            );
                         } else {
                             metrics.methodTime('storage_put_file', Date.now() - startTime, { driver_type: this.type });
 
@@ -188,7 +190,9 @@ export class S3StorageDriver extends StorageDriver {
                                 driver_type: this.type,
                             });
 
-                            reject(new DriverError(this.getContext('Delete File'), DriverError.States.UnknownError, err));
+                            reject(
+                                new DriverError(this.getContext('Delete File'), DriverError.States.UnknownError, err),
+                            );
                         }
                     } else {
                         metrics.methodTime('storage_remove_file', Date.now() - startTime, { driver_type: this.type });
@@ -212,7 +216,13 @@ export class S3StorageDriver extends StorageDriver {
 
         if (listedObjects.Contents.length === 0) return;
 
-        if (!recursive) throw new DriverError(this.getContext('Remove Directory'), DriverError.States.RequestError, null, 'Directory not empty');
+        if (!recursive)
+            throw new DriverError(
+                this.getContext('Remove Directory'),
+                DriverError.States.RequestError,
+                null,
+                'Directory not empty',
+            );
 
         const deleteParams = {
             Bucket: this.bucket,
@@ -252,7 +262,9 @@ export class S3StorageDriver extends StorageDriver {
                                 driver_type: this.type,
                             });
 
-                            reject(new DriverError(this.getContext('Head Object'), DriverError.States.UnknownError, err));
+                            reject(
+                                new DriverError(this.getContext('Head Object'), DriverError.States.UnknownError, err),
+                            );
                         }
                     } else {
                         if (data.DeleteMarker) {
@@ -322,7 +334,13 @@ export class S3StorageDriver extends StorageDriver {
                             try {
                                 subDirListing = await this._listDirectoryImplementation(subPrefix, recursive);
                             } catch (err) {
-                                reject(new DriverError(this.getContext('List Objects'), DriverError.States.UnknownError, err));
+                                reject(
+                                    new DriverError(
+                                        this.getContext('List Objects'),
+                                        DriverError.States.UnknownError,
+                                        err,
+                                    ),
+                                );
                             }
 
                             directoryListing.addDirectory(subDirListing);

--- a/src/storage/drivers/SftpStorageDriver.ts
+++ b/src/storage/drivers/SftpStorageDriver.ts
@@ -34,7 +34,7 @@ export class SftpStorageDriver extends StorageDriver {
             await client.connect(this.config.credentials);
             return client;
         } catch (err) {
-            throw new DriverError(DriverError.States.ConnectionError, err);
+            throw new DriverError(this.getContext('Connect'), DriverError.States.ConnectionError, err);
         }
     }
 
@@ -59,7 +59,7 @@ export class SftpStorageDriver extends StorageDriver {
                 if (err.message.includes('No such file')) {
                     await sftp.mkdir(newDirPath);
                 } else {
-                    throw new DriverError(DriverError.States.NotFoundError, err);
+                    throw new DriverError(`SFTP Make Directory`, DriverError.States.NotFoundError, err);
                 }
             }
         }
@@ -73,7 +73,7 @@ export class SftpStorageDriver extends StorageDriver {
             if (err.message.includes('No such file')) {
                 await SftpStorageDriver._safeRecursiveMkdir(sftp, parsedPath.dir);
             } else {
-                throw new DriverError(DriverError.States.NotFoundError, err);
+                throw new DriverError(this.getContext('List Directory'), DriverError.States.NotFoundError, err);
             }
         }
     }
@@ -99,7 +99,7 @@ export class SftpStorageDriver extends StorageDriver {
         } catch (err) {
             sftp.end();
             metrics.methodTime('storage_get_file', Date.now() - startTime, { driver_type: this.type });
-            throw new DriverError(DriverError.States.NotFoundError, err);
+            throw new DriverError(this.getContext('Read File'), DriverError.States.NotFoundError, err);
         }
     }
 
@@ -109,7 +109,7 @@ export class SftpStorageDriver extends StorageDriver {
         let encoding = binary ? null : 'utf8';
 
         if (!data) {
-            throw new DriverError(DriverError.States.ParameterError, null, 'Missing file content');
+            throw new DriverError(this.getContext('Write File'), DriverError.States.ParameterError, null, 'Missing file content');
         }
 
         let sftp = await this._connect();
@@ -128,7 +128,7 @@ export class SftpStorageDriver extends StorageDriver {
         } catch (err) {
             sftp.end();
             metrics.methodTime('storage_put_file', Date.now() - startTime, { driver_type: this.type });
-            throw new DriverError(DriverError.States.RequestError, err);
+            throw new DriverError(this.getContext('Write File'), DriverError.States.RequestError, err);
         }
     }
 
@@ -151,7 +151,7 @@ export class SftpStorageDriver extends StorageDriver {
                 return;
             }
             metrics.methodTime('storage_remove_file', Date.now() - startTime, { driver_type: this.type });
-            throw new DriverError(DriverError.States.RequestError, err);
+            throw new DriverError(this.getContext('Delete File'), DriverError.States.RequestError, err);
         }
     }
 
@@ -174,7 +174,7 @@ export class SftpStorageDriver extends StorageDriver {
                 return;
             }
             metrics.methodTime('storage_remove_directory', Date.now() - startTime, { driver_type: this.type });
-            throw new DriverError(DriverError.States.RequestError, err);
+            throw new DriverError(this.getContext('Remove Directory'), DriverError.States.RequestError, err);
         }
     }
 
@@ -237,9 +237,9 @@ export class SftpStorageDriver extends StorageDriver {
             if (!vaultDirectory && err.message.includes('No such file')) {
                 return new DirectoryListing('.');
             } else if (vaultDirectory && err.message.includes('No such file')) {
-                throw new DriverError(DriverError.States.NotFoundError, err);
+                throw new DriverError(this.getContext('List Directory'), DriverError.States.NotFoundError, err);
             } else {
-                throw new DriverError(DriverError.States.RequestError, err);
+                throw new DriverError(this.getContext('List Directory'), DriverError.States.RequestError, err);
             }
         }
     }

--- a/src/storage/drivers/SftpStorageDriver.ts
+++ b/src/storage/drivers/SftpStorageDriver.ts
@@ -109,7 +109,12 @@ export class SftpStorageDriver extends StorageDriver {
         let encoding = binary ? null : 'utf8';
 
         if (!data) {
-            throw new DriverError(this.getContext('Write File'), DriverError.States.ParameterError, null, 'Missing file content');
+            throw new DriverError(
+                this.getContext('Write File'),
+                DriverError.States.ParameterError,
+                null,
+                'Missing file content',
+            );
         }
 
         let sftp = await this._connect();


### PR DESCRIPTION
Engine needs to allow testing of StorageCredentials prior to creating the entity.  Additionally, DriverErrors generated from interaction with StorageDriver Implementations need to include context for the action triggering the error.

There is a new RPC endpoint `storage_credentials.validate_create` that takes arguments in the same format as `storage_credentials.create_hosted` and runs a connectivity test.  If the test is successful, the entity is created and returned with the same response format as create_hosted.  If the test fails, the resulting error message is returned with the same response format as a failed `storage_credentials.test` method call.