### PR TITLE
RPC Unit Tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -15,7 +15,9 @@ module.exports = {
     ],
     "collectCoverage": true,
     "collectCoverageFrom": [
+        "rpc/**/*.ts",
         "src/**/*.ts",
+        "!<rootDir>/rpc/__tests__/*",
         "!<rootDir>/src/__tests__/*",
         "!<rootDir>/src/Logger.ts",
         "!<rootDir>/src/entity/migration/*",

--- a/jest.config.js
+++ b/jest.config.js
@@ -18,21 +18,24 @@ module.exports = {
         "rpc/**/*.ts",
         "src/**/*.ts",
         "!<rootDir>/rpc/__tests__/*",
+        "!<rootDir>/rpc/Load/1.0.2/*",
         "!<rootDir>/src/__tests__/*",
         "!<rootDir>/src/Logger.ts",
         "!<rootDir>/src/entity/migration/*",
-        "!<rootDir>/src/shipchain/contracts/**/*"
+        "!<rootDir>/src/shipchain/contracts/**/*",
+        "!<rootDir>/src/shipchain/__tests__/*"
     ],
     "coverageReporters": [
         "text",
+        "text-summary",
         "html"
     ],
     "coverageThreshold": {
         "global": {
-            "branches": 0,
-            "functions": 0,
-            "lines": 0,
-            "statements": 0
+            "branches": 60,
+            "functions": 75,
+            "lines": 75,
+            "statements": 75
         }
     },
     "coverageDirectory": "<rootDir>/reports/coverage/",

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
     "transform": {
         "^.+\\.tsx?$": "ts-jest"
     },
-    "testRegex": "(/__tests__/.*|(\\.|/)(test|spec))\\.(tsx?)$",
+    "testRegex": "/jest.testOrder.ts$",
     "moduleFileExtensions": [
         "ts",
         "tsx",

--- a/jest.testOrder.ts
+++ b/jest.testOrder.ts
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+
+require('./src/__tests__/testLoggingConfig');
+
+import 'mocha';
+import * as typeorm from "typeorm";
+import { CloseConnection as CloseRedis } from "./src/redis";
+import { loadContractFixtures, LoadedContracts } from "./rpc/contracts";
+import { cleanupDeployedContracts } from "./rpc/__tests__/utils";
+
+
+// RPC Tests
+// =========
+import { RPCEventTests } from './rpc/__tests__/event';
+import { RPCVaultTests } from './rpc/__tests__/vault';
+import { RPCStorageCredentialsTests } from './rpc/__tests__/storage_credentials';
+import { RPCTransactions } from './rpc/__tests__/transaction';
+import { RPCWalletTests } from './rpc/__tests__/wallet';
+
+
+// SRC Tests
+// =========
+import { ContractEntityTests } from './src/__tests__/contracts';
+import { StorageCredentialEntityTests } from './src/__tests__/credentials';
+import { EventSubscriptionEntityTests } from './src/__tests__/eventsubscriptions';
+import { StorageDriverTests } from './src/__tests__/storage';
+import { VaultTests } from './src/__tests__/vaults';
+import { WalletEntityTests } from './src/__tests__/wallets';
+import { LoadVaultTests } from './src/shipchain/__tests__/loadvault';
+
+
+describe('RPC', async () => {
+
+    beforeAll(async () => {
+        try {
+            // read connection options from ormconfig file (or ENV variables)
+            const connectionOptions = await typeorm.getConnectionOptions();
+            await typeorm.createConnection(connectionOptions);
+            await loadContractFixtures();
+        } catch(err){
+            console.error(`beforeAll Error ${err}`);
+        }
+    }, 10000);
+
+    afterAll(async() => {
+        try {
+            await cleanupDeployedContracts(typeorm);
+            let conn = await typeorm.getConnection();
+            await conn.close();
+            await CloseRedis();
+        } catch(err){
+            console.error(`afterAll Error ${err}`);
+        }
+    }, 10000);
+
+    describe('Events', RPCEventTests);
+    describe('Vaults', RPCVaultTests);
+    describe('Storage', RPCStorageCredentialsTests);
+    describe('Transactions', RPCTransactions);
+    describe('Wallets', RPCWalletTests);
+
+});
+
+describe('Core', async () => {
+    beforeAll(async () => {
+        try {
+            // read connection options from ormconfig file (or ENV variables)
+            const connectionOptions = await typeorm.getConnectionOptions();
+            await typeorm.createConnection(connectionOptions);
+        } catch(err){
+            console.error(`beforeAll Error ${err}`);
+        }
+    }, 10000);
+
+    afterAll(async() => {
+        try {
+            await cleanupDeployedContracts(typeorm);
+            let conn = await typeorm.getConnection();
+            await conn.close();
+            await CloseRedis();
+        } catch(err){
+            console.error(`afterAll Error ${err}`);
+        }
+    }, 10000);
+
+    describe('Contracts', ContractEntityTests);
+    describe('StorageCredentials', StorageCredentialEntityTests);
+    describe('EventSubscriptions', EventSubscriptionEntityTests);
+    describe('StorageDriver', StorageDriverTests);
+    describe('Vaults', VaultTests);
+    describe('Wallets', WalletEntityTests);
+
+});
+
+describe('ShipChain', async () => {
+    beforeAll(async () => {
+        try {
+            // read connection options from ormconfig file (or ENV variables)
+            const connectionOptions = await typeorm.getConnectionOptions();
+            await typeorm.createConnection(connectionOptions);
+        } catch(err){
+            console.error(`beforeAll Error ${err}`);
+        }
+    }, 10000);
+
+    afterAll(async() => {
+        try {
+            await cleanupDeployedContracts(typeorm);
+            let conn = await typeorm.getConnection();
+            await conn.close();
+            await CloseRedis();
+        } catch(err){
+            console.error(`afterAll Error ${err}`);
+        }
+    }, 10000);
+
+    describe('LOAD Vault', LoadVaultTests);
+
+});

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "server": "ts-node rpc-server.ts",
     "ingest_primitives": "node ingestPrimitives.js",
     "start": "nodemon -e 'ts' -x 'ts-node' rpc-server.ts",
-    "clean": "rm -rf ./dist && find src -name '*.js' -name '*.js.map' ! -name 'testLoggingConfig.js' -delete",
+    "clean": "rm -rf ./dist && find src -name '*.js' ! -name 'testLoggingConfig.js' -delete && find src -name '*.js.map' ! -name 'testLoggingConfig.js' -delete && find rpc -name '*.js' -delete && find rpc -name '*.js.map' -delete",
     "prettier": "./node_modules/.bin/prettier --write 'src/**/*.ts' 'rpc/**/*.ts' ",
     "typeorm": "ts-node ./node_modules/.bin/typeorm",
     "migrate": "ts-node RunMigrations.ts"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint": "eslint 'src/**/*.ts' 'rpc/**/*.ts' ",
     "lint-junit": "eslint 'src/**/*.ts' 'rpc/**/*.ts' --format junit -o reports/junit/lint-junit.xml ",
     "lint-html": "eslint  'src/**/*.ts' 'rpc/**/*.ts' --format html  -o reports/lint.html ",
-    "test": "jest --detectOpenHandles --forceExit --maxWorkers=3",
+    "test": "jest --detectOpenHandles --forceExit --runInBand",
     "server": "ts-node rpc-server.ts",
     "ingest_primitives": "node ingestPrimitives.js",
     "start": "nodemon -e 'ts' -x 'ts-node' rpc-server.ts",

--- a/rpc/__tests__/event.ts
+++ b/rpc/__tests__/event.ts
@@ -22,27 +22,17 @@ import * as typeorm from "typeorm";
 import {
     mochaAsync,
     expectMissingRequiredParams,
-    cleanupDeployedContracts,
+    cleanupEntities,
     CallRPCMethod,
 } from "./utils";
 
 import { RPCEvent } from '../event';
 import { EventSubscription } from "../../src/entity/EventSubscription";
-import { loadContractFixtures } from "../contracts";
 
-describe('RPC Events', function() {
+export const RPCEventTests = async function() {
 
-    beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
-        await loadContractFixtures();
-    });
-
-    afterAll(async () => {
-        await cleanupDeployedContracts(typeorm);
+    afterAll(async() => {
+        await cleanupEntities(typeorm);
     });
 
     describe('Subscribe', function() {
@@ -133,4 +123,4 @@ describe('RPC Events', function() {
         }));
     });
 
-});
+};

--- a/rpc/__tests__/event.ts
+++ b/rpc/__tests__/event.ts
@@ -22,8 +22,8 @@ import * as typeorm from "typeorm";
 import {
     mochaAsync,
     expectMissingRequiredParams,
-    resolveCallback,
     cleanupDeployedContracts,
+    CallRPCMethod,
 } from "./utils";
 
 import { RPCEvent } from '../event';
@@ -50,7 +50,7 @@ describe('RPC Events', function() {
             let caughtError;
 
             try {
-                await RPCEvent.Subscribe({});
+                await CallRPCMethod(RPCEvent.Subscribe,{});
                 fail("Did not Throw"); return;
             } catch (err) {
                 caughtError = err;
@@ -61,13 +61,9 @@ describe('RPC Events', function() {
 
         it(`Throws if Project not found`, mochaAsync(async () => {
             try {
-                await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCEvent.Subscribe(
-                        {
-                            url: 'URL',
-                            project: 'not a project',
-                        }, null, resolveCallback(resolve, reject));
+                await CallRPCMethod(RPCEvent.Subscribe, {
+                    url: 'URL',
+                    project: 'not a project',
                 });
                 fail('Did not Throw');
             } catch (err){
@@ -78,13 +74,9 @@ describe('RPC Events', function() {
         it(`Returns new subscription`, mochaAsync(async () => {
             expect(await EventSubscription.count()).toEqual(0);
             try {
-                const response: any = await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCEvent.Subscribe(
-                        {
-                            url: 'URL',
-                            project: 'LOAD',
-                        }, null, resolveCallback(resolve, reject));
+                const response: any = await CallRPCMethod(RPCEvent.Subscribe,{
+                    url: 'URL',
+                    project: 'LOAD',
                 });
 
                 expect(response).toBeDefined();
@@ -105,7 +97,7 @@ describe('RPC Events', function() {
             let caughtError;
 
             try {
-                await RPCEvent.Unsubscribe({});
+                await CallRPCMethod(RPCEvent.Unsubscribe,{});
                 fail("Did not Throw"); return;
             } catch (err) {
                 caughtError = err;
@@ -116,13 +108,9 @@ describe('RPC Events', function() {
 
         it(`Throw if subscription does not exist`, mochaAsync(async () => {
             try {
-                await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCEvent.Unsubscribe(
-                        {
-                            url: 'URL',
-                            project: 'please fail',
-                        }, null, resolveCallback(resolve, reject));
+                await CallRPCMethod(RPCEvent.Unsubscribe,{
+                    url: 'URL',
+                    project: 'please fail',
                 });
                 fail('Did not Throw');
             } catch (err){
@@ -133,13 +121,9 @@ describe('RPC Events', function() {
         it(`Successfully unsubscribe`, mochaAsync(async () => {
             expect(await EventSubscription.count()).toEqual(1);
             try {
-                const response: any = await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCEvent.Unsubscribe(
-                        {
-                            url: 'URL',
-                            project: 'LOAD',
-                        }, null, resolveCallback(resolve, reject));
+                const response: any = await CallRPCMethod(RPCEvent.Unsubscribe,{
+                    url: 'URL',
+                    project: 'LOAD',
                 });
                 expect(response).toBeDefined();
             } catch (err){

--- a/rpc/__tests__/event.ts
+++ b/rpc/__tests__/event.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+require('../../src/__tests__/testLoggingConfig');
+
+import 'mocha';
+import * as typeorm from "typeorm";
+import {
+    mochaAsync,
+    expectMissingRequiredParams,
+    resolveCallback,
+    cleanupDeployedContracts,
+} from "./utils";
+
+import { RPCEvent } from '../event';
+import { EventSubscription } from "../../src/entity/EventSubscription";
+import { loadContractFixtures } from "../contracts";
+
+describe('RPC Events', function() {
+
+    beforeAll(async () => {
+        // read connection options from ormconfig file (or ENV variables)
+        const connectionOptions = await typeorm.getConnectionOptions();
+        await typeorm.createConnection({
+            ...connectionOptions,
+        });
+        await loadContractFixtures();
+    });
+
+    afterAll(async () => {
+        await cleanupDeployedContracts(typeorm);
+    });
+
+    describe('Subscribe', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await RPCEvent.Subscribe({});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['url', 'project']);
+        }));
+
+        it(`Throws if Project not found`, mochaAsync(async () => {
+            try {
+                await new Promise((resolve, reject) => {
+                    // @ts-ignore
+                    RPCEvent.Subscribe(
+                        {
+                            url: 'URL',
+                            project: 'not a project',
+                        }, null, resolveCallback(resolve, reject));
+                });
+                fail('Did not Throw');
+            } catch (err){
+                expect(err.message).toEqual('Contract \'not a project\' not registered');
+            }
+        }));
+
+        it(`Returns new subscription`, mochaAsync(async () => {
+            expect(await EventSubscription.count()).toEqual(0);
+            try {
+                const response: any = await new Promise((resolve, reject) => {
+                    // @ts-ignore
+                    RPCEvent.Subscribe(
+                        {
+                            url: 'URL',
+                            project: 'LOAD',
+                        }, null, resolveCallback(resolve, reject));
+                });
+
+                expect(response).toBeDefined();
+                expect(response.success).toBeTruthy();
+                expect(response.subscription).toBeDefined();
+                expect(response.subscription.contract).toEqual('LOAD');
+                expect(response.subscription.callback).toEqual('URL');
+                expect(response.subscription.events).toEqual(['allEvents']);
+            } catch (err){
+                fail(`Should not have thrown [${err}]`);
+            }
+            expect(await EventSubscription.count()).toEqual(1);
+        }));
+    });
+
+    describe('Unsubscribe', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await RPCEvent.Unsubscribe({});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['url', 'project']);
+        }));
+
+        it(`Throw if subscription does not exist`, mochaAsync(async () => {
+            try {
+                await new Promise((resolve, reject) => {
+                    // @ts-ignore
+                    RPCEvent.Unsubscribe(
+                        {
+                            url: 'URL',
+                            project: 'please fail',
+                        }, null, resolveCallback(resolve, reject));
+                });
+                fail('Did not Throw');
+            } catch (err){
+                expect(err.message).toEqual('EventSubscription not found');
+            }
+        }));
+
+        it(`Successfully unsubscribe`, mochaAsync(async () => {
+            expect(await EventSubscription.count()).toEqual(1);
+            try {
+                const response: any = await new Promise((resolve, reject) => {
+                    // @ts-ignore
+                    RPCEvent.Unsubscribe(
+                        {
+                            url: 'URL',
+                            project: 'LOAD',
+                        }, null, resolveCallback(resolve, reject));
+                });
+                expect(response).toBeDefined();
+            } catch (err){
+                fail(`Should not have thrown [${err}]`);
+            }
+            expect(await EventSubscription.count()).toEqual(0);
+        }));
+    });
+
+});

--- a/rpc/__tests__/storage_credentials.ts
+++ b/rpc/__tests__/storage_credentials.ts
@@ -25,20 +25,17 @@ import {
     expectMissingRequiredParams,
     expectInvalidUUIDParams,
     expectInvalidStringParams,
+    cleanupEntities,
     CallRPCMethod,
 } from "./utils";
 
 import { RPCStorageCredentials } from '../storage_credentials';
 import { StorageCredential } from "../../src/entity/StorageCredential";
 
-describe('RPC StorageCredentials', function() {
+export const RPCStorageCredentialsTests = async function() {
 
-    beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
+    afterAll(async() => {
+        await cleanupEntities(typeorm);
     });
 
     describe('Create', function() {
@@ -307,7 +304,6 @@ describe('RPC StorageCredentials', function() {
                 const response: any = await CallRPCMethod(RPCStorageCredentials.TestConnectivity,{
                     storageCredentials: existingSC.id,
                 });
-                console.log(response);
                 expect(response.valid).toBeTruthy();
             } catch (err) {
                 fail(`Should not have thrown [${err}]`);
@@ -316,4 +312,4 @@ describe('RPC StorageCredentials', function() {
             expect(await StorageCredential.count()).toEqual(initialCount);
         }));
     });
-});
+};

--- a/rpc/__tests__/storage_credentials.ts
+++ b/rpc/__tests__/storage_credentials.ts
@@ -1,0 +1,319 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+require('../../src/__tests__/testLoggingConfig');
+
+import 'mocha';
+import * as typeorm from "typeorm";
+import {
+    mochaAsync,
+    expectMissingRequiredParams,
+    expectInvalidUUIDParams,
+    expectInvalidStringParams,
+    CallRPCMethod,
+} from "./utils";
+
+import { RPCStorageCredentials } from '../storage_credentials';
+import { StorageCredential } from "../../src/entity/StorageCredential";
+
+describe('RPC StorageCredentials', function() {
+
+    beforeAll(async () => {
+        // read connection options from ormconfig file (or ENV variables)
+        const connectionOptions = await typeorm.getConnectionOptions();
+        await typeorm.createConnection({
+            ...connectionOptions,
+        });
+    });
+
+    describe('Create', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+            const initialCount = await StorageCredential.count();
+
+            try {
+                await CallRPCMethod(RPCStorageCredentials.Create,{});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['title', 'driver_type']);
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+
+        it(`Validates String parameter`, mochaAsync(async () => {
+            let caughtError;
+            const initialCount = await StorageCredential.count();
+
+            try {
+                const result:any = await CallRPCMethod(RPCStorageCredentials.Create,{
+                    title: {what: ['is', 'this']},
+                    driver_type: 'local',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidStringParams(caughtError, ['title']);
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+
+        it(`Validates driver_type parameter`, mochaAsync(async () => {
+            const initialCount = await StorageCredential.count();
+
+            try {
+                await CallRPCMethod(RPCStorageCredentials.Create,{
+                    title: 'new title',
+                    driver_type: 'INVALID',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Driver type: INVALID, not allowed!');
+            }
+
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+
+        it(`Returns new StorageCredentials`, mochaAsync(async () => {
+            const initialCount = await StorageCredential.count();
+
+            try {
+                const response: any = await CallRPCMethod(RPCStorageCredentials.Create,{
+                    title: 'new title',
+                    driver_type: 'local',
+                });
+                expect(response.success).toBeTruthy();
+                expect(response.credentials.title).toEqual('new title');
+                expect(response.credentials.driver_type).toEqual('local');
+                expect(response.credentials.base_path).toEqual('./');
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await StorageCredential.count()).toEqual(initialCount + 1);
+        }));
+    });
+
+    describe('List', function() {
+        it('Requires no parameters', mochaAsync(async () => {
+            const initialCount = await StorageCredential.count();
+
+            try {
+                const response: any = await CallRPCMethod(RPCStorageCredentials.List, null);
+                expect(response.success).toBeTruthy();
+                expect(response.credentials.length).toEqual(initialCount);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+    });
+
+    describe('TestAndStore', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+            const initialCount = await StorageCredential.count();
+
+            try {
+                await CallRPCMethod(RPCStorageCredentials.TestAndStore,{});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['title', 'driver_type']);
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+
+        it(`Validates String parameter`, mochaAsync(async () => {
+            let caughtError;
+            const initialCount = await StorageCredential.count();
+
+            try {
+                const result:any = await CallRPCMethod(RPCStorageCredentials.TestAndStore,{
+                    title: {what: ['is', 'this']},
+                    driver_type: 'local',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidStringParams(caughtError, ['title']);
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+
+        it(`Validates driver_type parameter`, mochaAsync(async () => {
+            const initialCount = await StorageCredential.count();
+
+            try {
+                await CallRPCMethod(RPCStorageCredentials.TestAndStore,{
+                    title: 'new title',
+                    driver_type: 'INVALID',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Driver type: INVALID, not allowed!');
+            }
+
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+
+        it(`Returns Error on failed test`, mochaAsync(async () => {
+            const initialCount = await StorageCredential.count();
+
+            try {
+                const response: any = await CallRPCMethod(RPCStorageCredentials.TestAndStore,{
+                    title: 'new title',
+                    driver_type: 'sftp',
+                    options: {
+                        credentials: {
+                            host: '__INVALID_HOST__',
+                            port: '9999',
+                        }
+                    }
+                });
+                expect(response.valid).toBeFalsy();
+                expect(response.message).toEqual('SFTP Connect: Error in Connection to Storage Driver [Invalid username]');
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+
+        it(`Returns new StorageCredentials on successful test`, mochaAsync(async () => {
+            const initialCount = await StorageCredential.count();
+
+            try {
+                const response: any = await CallRPCMethod(RPCStorageCredentials.TestAndStore,{
+                    title: 'new title',
+                    driver_type: 'local',
+                });
+                expect(response.success).toBeTruthy();
+                expect(response.credentials.title).toEqual('new title');
+                expect(response.credentials.driver_type).toEqual('local');
+                expect(response.credentials.base_path).toEqual('./');
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await StorageCredential.count()).toEqual(initialCount + 1);
+        }));
+    });
+
+    describe('Update', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCStorageCredentials.Update, null);
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCStorageCredentials.Update, {
+                    storageCredentials: '123'
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials']);
+        }));
+
+        it(`Correctly modifies record`, mochaAsync(async () => {
+            const initialCount = await StorageCredential.count();
+
+            try {
+                const existingSC: StorageCredential = (await StorageCredential.find())[0];
+
+                const response: any = await CallRPCMethod(RPCStorageCredentials.Update,{
+                    storageCredentials: existingSC.id,
+                    title: 'updated title',
+                });
+                expect(response.updated).toBeTruthy();
+                expect((await StorageCredential.getById(existingSC.id)).title).toEqual('updated title');
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+    });
+
+    describe('TestConnectivity', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCStorageCredentials.TestConnectivity, null);
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCStorageCredentials.TestConnectivity, {
+                    storageCredentials: '123'
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials']);
+        }));
+
+        it(`Correctly modifies record`, mochaAsync(async () => {
+            const initialCount = await StorageCredential.count();
+
+            try {
+                const existingSC: StorageCredential = (await StorageCredential.find())[0];
+
+                const response: any = await CallRPCMethod(RPCStorageCredentials.TestConnectivity,{
+                    storageCredentials: existingSC.id,
+                });
+                console.log(response);
+                expect(response.valid).toBeTruthy();
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await StorageCredential.count()).toEqual(initialCount);
+        }));
+    });
+});

--- a/rpc/__tests__/transaction.ts
+++ b/rpc/__tests__/transaction.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+require('../../src/__tests__/testLoggingConfig');
+
+import 'mocha';
+import * as typeorm from "typeorm";
+import * as Transaction from 'ethereumjs-tx';
+import { RPCTransaction } from '../transaction';
+import { mochaAsync, expectMissingRequiredParams, expectInvalidUUIDParams, resolveCallback } from './utils';
+
+import { Wallet } from "../../src/entity/Wallet";
+import { PrivateKeyDBFieldEncryption } from "../../src/entity/encryption/PrivateKeyDBFieldEncryption";
+
+describe('RPC Transactions', function() {
+
+    beforeAll(async () => {
+        // read connection options from ormconfig file (or ENV variables)
+        const connectionOptions = await typeorm.getConnectionOptions();
+        await typeorm.createConnection({
+            ...connectionOptions,
+        });
+        Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
+    });
+
+    describe('Sign', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await RPCTransaction.Sign({});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['signerWallet', 'txUnsigned']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await RPCTransaction.Sign({
+                    signerWallet: '',
+                    txUnsigned: {}
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['signerWallet']);
+        }));
+
+        it(`Validates TX Parameter is object`, mochaAsync(async () => {
+            try {
+                await new Promise((resolve, reject) => {
+                    // @ts-ignore
+                    RPCTransaction.Sign(
+                        {
+                            signerWallet: '00000000-0000-4000-8000-000000000000',
+                            txUnsigned: 'Transaction Unsigned String',
+                        }, null, resolveCallback(resolve, reject));
+                });
+                fail('Did not Throw');
+            } catch (err){
+                expect(err.message).toEqual('Invalid Ethereum Transaction format');
+            }
+        }));
+
+        it(`Throws if Wallet not found`, mochaAsync(async () => {
+            try {
+                await new Promise((resolve, reject) => {
+                    // @ts-ignore
+                    RPCTransaction.Sign(
+                        {
+                            signerWallet: '00000000-0000-4000-8000-000000000000',
+                            txUnsigned: {},
+                        }, null, resolveCallback(resolve, reject));
+                });
+                fail('Did not Throw');
+            } catch (err){
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Returns Signed Transaction`, mochaAsync(async () => {
+            const signer = await Wallet.generate_entity();
+            await signer.save();
+            try {
+                const response: any = await new Promise((resolve, reject) => {
+                    // @ts-ignore
+                    RPCTransaction.Sign(
+                        {
+                            signerWallet: signer.id,
+                            txUnsigned: {},
+                        }, null, resolveCallback(resolve, reject));
+                });
+
+                expect(response).toBeTruthy();
+                expect(response.success).toBeTruthy();
+                expect(response.hash).toMatch(/^0x[a-f0-9]{64}$/);
+                expect(response.transaction).toBeInstanceOf(Transaction);
+            } catch (err){
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+});

--- a/rpc/__tests__/transaction.ts
+++ b/rpc/__tests__/transaction.ts
@@ -24,30 +24,23 @@ import {
     mochaAsync,
     expectMissingRequiredParams,
     expectInvalidUUIDParams,
+    cleanupEntities,
     CallRPCMethod,
-    cleanupDeployedContracts,
 } from "./utils";
 
 import { RPCTransaction } from '../transaction';
 import { RPCLoad } from '../Load/1.1.0/RPCLoad';
 import { Wallet } from "../../src/entity/Wallet";
 import { PrivateKeyDBFieldEncryption } from "../../src/entity/encryption/PrivateKeyDBFieldEncryption";
-import { loadContractFixtures } from "../contracts";
 
-describe('RPC Transactions', function() {
+export const RPCTransactions = async function() {
 
     let fullWallet;
     let txUnsigned;
     let txSigned;
 
-    beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
+    beforeEach(async () => {
         Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
-        await loadContractFixtures();
 
         // Import known funded wallet
         fullWallet = await Wallet.import_entity('0x0000000000000000000000000000000000000000000000000000000000000001');
@@ -60,10 +53,10 @@ describe('RPC Transactions', function() {
         });
         txUnsigned = txUnsigned.transaction;
 
-    });
+    }, 10000);
 
-    afterAll(async () => {
-        await cleanupDeployedContracts(typeorm);
+    afterAll(async() => {
+        await cleanupEntities(typeorm);
     });
 
     describe('Sign', function() {
@@ -178,4 +171,4 @@ describe('RPC Transactions', function() {
         }));
     });
 
-});
+};

--- a/rpc/__tests__/transaction.ts
+++ b/rpc/__tests__/transaction.ts
@@ -15,13 +15,18 @@
  */
 
 
-
 require('../../src/__tests__/testLoggingConfig');
 
 import 'mocha';
 import * as typeorm from "typeorm";
 import * as Transaction from 'ethereumjs-tx';
-import { mochaAsync, expectMissingRequiredParams, expectInvalidUUIDParams, resolveCallback } from './utils';
+import {
+    mochaAsync,
+    expectMissingRequiredParams,
+    expectInvalidUUIDParams,
+    resolveCallback,
+    cleanupDeployedContracts
+} from "./utils";
 
 import { RPCTransaction } from '../transaction';
 import { RPCLoad } from '../Load/1.1.0/RPCLoad';
@@ -62,17 +67,7 @@ describe('RPC Transactions', function() {
     });
 
     afterAll(async () => {
-        // Since we are using `loadContractFixtures()` we need to cleanup the loaded conctracts
-        try {
-            const entities = ['Contract', 'Version', 'Network', 'Project'];
-            for (const entity of entities) {
-                const repository = await typeorm.getRepository(entity);
-                await repository.remove(await repository.find());
-            }
-        } catch (error) {
-            console.error(`Table Truncation Error ${error}`);
-            throw new Error(`ERROR: Cleaning test db: ${error}`);
-        }
+        await cleanupDeployedContracts(typeorm);
     });
 
     describe('Sign', function() {

--- a/rpc/__tests__/transaction.ts
+++ b/rpc/__tests__/transaction.ts
@@ -24,8 +24,8 @@ import {
     mochaAsync,
     expectMissingRequiredParams,
     expectInvalidUUIDParams,
-    resolveCallback,
-    cleanupDeployedContracts
+    CallRPCMethod,
+    cleanupDeployedContracts,
 } from "./utils";
 
 import { RPCTransaction } from '../transaction';
@@ -54,13 +54,9 @@ describe('RPC Transactions', function() {
         await fullWallet.save();
 
         // Generate a transaction to sign/send
-        txUnsigned = await new Promise((resolve, reject) => {
-            // @ts-ignore
-            RPCLoad.CreateShipmentTx(
-                {
-                    shipmentUuid: "77777777-25fe-465e-8458-0e9f8ffa2cdd",
-                    senderWallet: fullWallet.id,
-                }, null, resolveCallback(resolve, reject));
+        txUnsigned = await CallRPCMethod(RPCLoad.CreateShipmentTx, {
+            shipmentUuid: "77777777-25fe-465e-8458-0e9f8ffa2cdd",
+            senderWallet: fullWallet.id,
         });
         txUnsigned = txUnsigned.transaction;
 
@@ -75,7 +71,7 @@ describe('RPC Transactions', function() {
             let caughtError;
 
             try {
-                await RPCTransaction.Sign({});
+                await CallRPCMethod(RPCTransaction.Sign,{});
                 fail("Did not Throw"); return;
             } catch (err) {
                 caughtError = err;
@@ -88,7 +84,7 @@ describe('RPC Transactions', function() {
             let caughtError;
 
             try {
-                await RPCTransaction.Sign({
+                await CallRPCMethod(RPCTransaction.Sign,{
                     signerWallet: '',
                     txUnsigned: {}
                 });
@@ -102,13 +98,9 @@ describe('RPC Transactions', function() {
 
         it(`Validates TX Parameter is object`, mochaAsync(async () => {
             try {
-                await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCTransaction.Sign(
-                        {
-                            signerWallet: '00000000-0000-4000-8000-000000000000',
-                            txUnsigned: 'Transaction Unsigned String',
-                        }, null, resolveCallback(resolve, reject));
+                await CallRPCMethod(RPCTransaction.Sign, {
+                    signerWallet: '00000000-0000-4000-8000-000000000000',
+                    txUnsigned: 'Transaction Unsigned String',
                 });
                 fail('Did not Throw');
             } catch (err){
@@ -118,13 +110,9 @@ describe('RPC Transactions', function() {
 
         it(`Throws if Wallet not found`, mochaAsync(async () => {
             try {
-                await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCTransaction.Sign(
-                        {
-                            signerWallet: '00000000-0000-4000-8000-000000000000',
-                            txUnsigned: {},
-                        }, null, resolveCallback(resolve, reject));
+                await CallRPCMethod(RPCTransaction.Sign, {
+                    signerWallet: '00000000-0000-4000-8000-000000000000',
+                    txUnsigned: {},
                 });
                 fail('Did not Throw');
             } catch (err){
@@ -134,13 +122,9 @@ describe('RPC Transactions', function() {
 
         it(`Returns Signed Transaction`, mochaAsync(async () => {
             try {
-                const response: any = await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCTransaction.Sign(
-                        {
-                            signerWallet: fullWallet.id,
-                            txUnsigned: txUnsigned,
-                        }, null, resolveCallback(resolve, reject));
+                const response: any = await CallRPCMethod(RPCTransaction.Sign, {
+                    signerWallet: fullWallet.id,
+                    txUnsigned: txUnsigned,
                 });
 
                 expect(response).toBeDefined();
@@ -159,7 +143,7 @@ describe('RPC Transactions', function() {
             let caughtError;
 
             try {
-                await RPCTransaction.Send({});
+                await CallRPCMethod(RPCTransaction.Send,{});
                 fail("Did not Throw"); return;
             } catch (err) {
                 caughtError = err;
@@ -170,12 +154,8 @@ describe('RPC Transactions', function() {
 
         it(`Validates TX Parameter is object`, mochaAsync(async () => {
             try {
-                await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCTransaction.Send(
-                        {
-                            txSigned: 'Transaction Unsigned String',
-                        }, null, resolveCallback(resolve, reject));
+                await CallRPCMethod(RPCTransaction.Send, {
+                    txSigned: 'Transaction Unsigned String',
                 });
                 fail('Did not Throw');
             } catch (err){
@@ -185,12 +165,8 @@ describe('RPC Transactions', function() {
 
         it(`Returns Transaction Receipt`, mochaAsync(async () => {
             try {
-                const response: any = await new Promise((resolve, reject) => {
-                    // @ts-ignore
-                    RPCTransaction.Send(
-                        {
-                            txSigned: txSigned,
-                        }, null, resolveCallback(resolve, reject));
+                const response: any = await CallRPCMethod(RPCTransaction.Send, {
+                    txSigned: txSigned,
                 });
 
                 expect(response).toBeDefined();

--- a/rpc/__tests__/utils.ts
+++ b/rpc/__tests__/utils.ts
@@ -27,6 +27,19 @@ export const mochaAsync = fn => {
     };
 };
 
+export const cleanupDeployedContracts = async (typeorm: any) => {
+    try {
+        const entities = ['Contract', 'Version', 'Network', 'Project'];
+        for (const entity of entities) {
+            const repository = await typeorm.getRepository(entity);
+            await repository.remove(await repository.find());
+        }
+    } catch (error) {
+        console.error(`Table Truncation Error ${error}`);
+        throw new Error(`ERROR: Cleaning test db: ${error}`);
+    }
+};
+
 export const expectMissingRequiredParams = (throwable: Error, params: string[]) => {
     if(!throwable){
         fail("No Error when one was expected!");

--- a/rpc/__tests__/utils.ts
+++ b/rpc/__tests__/utils.ts
@@ -60,6 +60,16 @@ export const expectInvalidUUIDParams = (throwable: Error, params: string[]) => {
     expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
 };
 
+// RPCMethod decorator throws this error when provided argument does not match expected format
+export const expectInvalidStringParams = (throwable: Error, params: string[]) => {
+    if(!throwable){
+        fail("No Error when one was expected!");
+        return;
+    }
+    const missingPrefix = `Invalid String${params.length === 1 ? '' : 's'}`;
+    expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
+};
+
 // RPCMethod decorated methods are called in the RPC Server context which handles
 // returning data and/or errors via callbacks.  Since we're calling these directly
 // we need a utility method to act as that callback to resolve/reject from the method

--- a/rpc/__tests__/utils.ts
+++ b/rpc/__tests__/utils.ts
@@ -40,6 +40,7 @@ export const cleanupDeployedContracts = async (typeorm: any) => {
     }
 };
 
+// RPCMethod decorator throws this error when required argument not provided
 export const expectMissingRequiredParams = (throwable: Error, params: string[]) => {
     if(!throwable){
         fail("No Error when one was expected!");
@@ -49,6 +50,7 @@ export const expectMissingRequiredParams = (throwable: Error, params: string[]) 
     expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
 };
 
+// RPCMethod decorator throws this error when provided argument does not match expected format
 export const expectInvalidUUIDParams = (throwable: Error, params: string[]) => {
     if(!throwable){
         fail("No Error when one was expected!");
@@ -58,13 +60,25 @@ export const expectInvalidUUIDParams = (throwable: Error, params: string[]) => {
     expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
 };
 
-export const resolveCallback = (resolve: any, reject: any) => {
+// RPCMethod decorated methods are called in the RPC Server context which handles
+// returning data and/or errors via callbacks.  Since we're calling these directly
+// we need a utility method to act as that callback to resolve/reject from the method
+const resolveCallback = (resolve: any, reject: any) => {
     return (throwable: Error, data: any) => {
         if(throwable){
             reject(throwable);
         }
         resolve(data);
     };
+};
+
+// This makes calling the RPCMethod decorated methods easier as it injects the
+// callback handler created above and returns a promise that either returns the
+// result of the RPC method or raises an error with the rejection of the promise
+export const CallRPCMethod = async (method: any, args: any = null): Promise<any> => {
+    return new Promise((resolve, reject) => {
+        method(args, null, resolveCallback(resolve, reject))
+    });
 };
 
 

--- a/rpc/__tests__/utils.ts
+++ b/rpc/__tests__/utils.ts
@@ -85,6 +85,26 @@ export const expectInvalidStringParams = (throwable: Error, params: string[]) =>
     expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
 };
 
+// RPCMethod decorator throws this error when provided argument does not match expected format
+export const expectInvalidObjectParams = (throwable: Error, params: string[]) => {
+    if(!throwable){
+        fail("No Error when one was expected!");
+        return;
+    }
+    const missingPrefix = `Invalid Object${params.length === 1 ? '' : 's'}`;
+    expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
+};
+
+// RPCMethod decorator throws this error when provided argument does not match expected format
+export const expectInvalidDateParams = (throwable: Error, params: string[]) => {
+    if(!throwable){
+        fail("No Error when one was expected!");
+        return;
+    }
+    const missingPrefix = `Invalid Date${params.length === 1 ? '' : 's'}`;
+    expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
+};
+
 // RPCMethod decorated methods are called in the RPC Server context which handles
 // returning data and/or errors via callbacks.  Since we're calling these directly
 // we need a utility method to act as that callback to resolve/reject from the method

--- a/rpc/__tests__/utils.ts
+++ b/rpc/__tests__/utils.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// https://staxmanade.com/2015/11/testing-asyncronous-code-with-mochajs-and-es7-async-await/
+// Automatically wrap a test case with try/catch and call the async done() when it's complete
+export const mochaAsync = fn => {
+    return async done => {
+        try {
+            await fn();
+            done();
+        } catch (err) {
+            done(err);
+        }
+    };
+};
+
+export const expectMissingRequiredParams = (throwable: Error, params: string[]) => {
+    if(!throwable){
+        fail("No Error when one was expected!");
+        return;
+    }
+    const missingPrefix = `Missing required parameter${params.length === 1 ? '' : 's'}`;
+    expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
+};
+
+export const expectInvalidUUIDParams = (throwable: Error, params: string[]) => {
+    if(!throwable){
+        fail("No Error when one was expected!");
+        return;
+    }
+    const missingPrefix = `Invalid UUID${params.length === 1 ? '' : 's'}`;
+    expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
+};
+
+export const resolveCallback = (resolve: any, reject: any) => {
+    return (throwable: Error, data: any) => {
+        if(throwable){
+            reject(throwable);
+        }
+        resolve(data);
+    };
+};
+
+
+
+
+// Can't have a simple helper/utilities file
+// without Jest complaining for empty test file
+// This is enough to keep it quiet
+// ============================================
+it('', () => {});

--- a/rpc/__tests__/utils.ts
+++ b/rpc/__tests__/utils.ts
@@ -29,14 +29,29 @@ export const mochaAsync = fn => {
 
 export const cleanupDeployedContracts = async (typeorm: any) => {
     try {
-        const entities = ['Contract', 'Version', 'Network', 'Project'];
+        const entities = [
+            'Contract', 'Version', 'Network', 'Project',
+        ];
         for (const entity of entities) {
-            const repository = await typeorm.getRepository(entity);
+            const repository = await typeorm.getConnection().getRepository(entity);
             await repository.remove(await repository.find());
         }
     } catch (error) {
         console.error(`Table Truncation Error ${error}`);
-        throw new Error(`ERROR: Cleaning test db: ${error}`);
+    }
+};
+
+export const cleanupEntities = async (typeorm: any) => {
+    try {
+        const entities = [
+            'EventSubscription', 'StorageCredential', 'Wallet',
+        ];
+        for (const entity of entities) {
+            const repository = await typeorm.getConnection().getRepository(entity);
+            await repository.remove(await repository.find());
+        }
+    } catch (error) {
+        console.error(`Table Truncation Error ${error}`);
     }
 };
 

--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -19,29 +19,60 @@
 
 require('../../src/__tests__/testLoggingConfig');
 
+const fs = require('fs');
+
 import 'mocha';
 import * as typeorm from "typeorm";
 import {
     mochaAsync,
     expectMissingRequiredParams,
     expectInvalidUUIDParams,
+    expectInvalidDateParams,
     cleanupEntities,
     CallRPCMethod,
 } from "./utils";
 
+import { buildSchemaValidators } from "../validators";
 import { RPCVault } from '../vault';
 import { uuidv4 } from "../../src/utils";
 import { StorageCredential } from "../../src/entity/StorageCredential";
 import { Wallet } from "../../src/entity/Wallet";
 import { PrivateKeyDBFieldEncryption } from "../../src/entity/encryption/PrivateKeyDBFieldEncryption";
 
+const DATE_0 = '2018-01-01T00:00:00.000Z';
+const DATE_1 = '2018-01-01T01:00:00.000Z';
+const DATE_2 = '2018-01-01T02:00:00.000Z';
+const DATE_3 = '2018-01-01T03:00:00.000Z';
+const DATE_4 = '2018-01-01T04:00:00.000Z';
+
 export const RPCVaultTests = async function() {
+    const RealDate = Date;
+
+    function mockDate(isoDate) {
+        // @ts-ignore
+        global.Date = class extends RealDate {
+            constructor() {
+                super();
+                return new RealDate(isoDate);
+            }
+        };
+    }
+
+    function resetDate() {
+        // @ts-ignore
+        global.Date = RealDate;
+    }
+
 
     let fullWallet1;
     let fullWallet2;
     let localStorage;
 
-    let testableVaultId;
+    let testableLocalVaultId;
+    let emptyLocalVaultId;
+
+    let knownShipmentSchemaId = uuidv4();
+    let knownDocumentContent = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mN8U+T4nYEIwDiqkL4KAZKnGefMCAbPAAAAAElFTkSuQmCC';
 
     beforeAll(async () => {
         Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
@@ -58,7 +89,18 @@ export const RPCVaultTests = async function() {
         });
         await localStorage.save();
 
+        await buildSchemaValidators();
+
     });
+
+    beforeEach(async () => {
+        mockDate(DATE_1);
+    });
+
+    afterEach(async () => {
+        resetDate();
+    });
+
 
     afterAll(async() => {
         await cleanupEntities(typeorm);
@@ -151,7 +193,7 @@ export const RPCVaultTests = async function() {
             }
         }));
 
-        it(`Returns new Vault`, mochaAsync(async () => {
+        it(`Creates new Vault`, mochaAsync(async () => {
             try {
                 const result: any = await CallRPCMethod(RPCVault.CreateVault, {
                     storageCredentials: localStorage.id,
@@ -168,9 +210,1051 @@ export const RPCVaultTests = async function() {
                 expect(result.vault_signed.signature).toBeDefined();
                 expect(result.vault_signed.alg).toEqual('sha256');
                 expect(result.vault_uri).toBeDefined();
+                expect(fs.existsSync(`./${result.vault_id}/meta.json`)).toBeTruthy();
 
                 // Save this vault_id for use in later tests
-                testableVaultId = result.vault_id;
+                testableLocalVaultId = result.vault_id;
+
+                // Create empty vault for later tests
+                const emptyVaultResult: any = await CallRPCMethod(RPCVault.CreateVault, {
+                    storageCredentials: localStorage.id,
+                    shipperWallet: fullWallet1.id,
+                    carrierWallet: fullWallet2.id,
+                });
+                emptyLocalVaultId = emptyVaultResult.vault_id;
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('AddTrackingData', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.AddTrackingData, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'payload']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.AddTrackingData, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddTrackingData, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Validates Payload is object`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: 'a string',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Invalid Object: 'payload'`);
+            }
+
+            try {
+                await CallRPCMethod(RPCVault.AddTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: [],
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Invalid Object: 'payload'`);
+            }
+        }));
+
+        it(`Adds new data`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.AddTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: {
+                        some: 'data'
+                    },
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.vault_signed).toBeDefined();
+                expect(fs.existsSync(`./${testableLocalVaultId}/tracking/20180101.json`)).toBeTruthy();
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('GetTrackingData', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetTrackingData, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetTrackingData, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetTrackingData, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Returns empty array when no tracking data exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.GetTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: emptyLocalVaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.contents).toEqual([]);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Returns correct tracking data when exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.GetTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.contents).toEqual([{
+                    some: 'data'
+                }]);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('AddShipmentData', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.AddShipmentData, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'shipment']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                    shipment: {id: uuidv4(), version: '0.0.1'},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    shipment: {id: uuidv4(), version: '0.0.1'},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                    shipment: {id: uuidv4(), version: '0.0.1'},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                    shipment: {id: uuidv4(), version: '0.0.1'},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Validates Shipment is object`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    shipment: 'a string',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Invalid Object: 'shipment'`);
+            }
+
+            try {
+                await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    shipment: [],
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Invalid Object: 'shipment'`);
+            }
+        }));
+
+        it(`Validates Shipment matches schema`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    shipment: {
+                        id: uuidv4(),
+                        version: '0.0.1',
+                        invalid_shipment_field: 'Fail',
+                    },
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Shipment Invalid: data should NOT have additional properties`);
+            }
+        }));
+
+        it(`Adds new data`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    shipment: {
+                        id: knownShipmentSchemaId,
+                        version: '0.0.1',
+                    },
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.vault_signed).toBeDefined();
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('GetShipmentData', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetShipmentData, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetShipmentData, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetShipmentData, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Throws when no tracking data exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: emptyLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Container contents empty`);
+            }
+        }));
+
+        it(`Returns correct tracking data when exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.GetShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.shipment).toEqual({
+                    id: knownShipmentSchemaId,
+                    version: '0.0.1',
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('AddDocument', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.AddDocument, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'documentName', 'documentContent']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.AddDocument, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                    documentName: 'test.png',
+                    documentContent: knownDocumentContent,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddDocument, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    documentName: 'test.png',
+                    documentContent: knownDocumentContent,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                    documentName: 'test.png',
+                    documentContent: knownDocumentContent,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                    documentName: 'test.png',
+                    documentContent: knownDocumentContent,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Validates documentName is string`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    documentName: {},
+                    documentContent: knownDocumentContent,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Invalid String: 'documentName'`);
+            }
+        }));
+
+        it(`Validates documentContent is string`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    documentName: 'test.png',
+                    documentContent: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Invalid String: 'documentContent'`);
+            }
+        }));
+
+        it(`Adds new data`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.AddDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    documentName: 'test.png',
+                    documentContent: knownDocumentContent,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.vault_signed).toBeDefined();
+                expect(fs.existsSync(`./${testableLocalVaultId}/documents/test.png.json`)).toBeTruthy();
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('GetDocument', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetDocument, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'documentName']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetDocument, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                    documentName: 'test.png',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetDocument, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    documentName: 'test.png',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                    documentName: 'test.png',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                    documentName: 'test.png',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Validates documentName is string`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    documentName: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Invalid String: 'documentName'`);
+            }
+        }));
+
+        it(`Throws no document exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: emptyLocalVaultId,
+                    documentName: 'test.png',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unauthorized access to vault contents`);
+            }
+        }));
+
+        it(`Returns correct document data when exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.GetDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    documentName: 'test.png',
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.document).toEqual(knownDocumentContent);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('ListDocuments', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.ListDocuments, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vault']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.ListDocuments, {
+                    storageCredentials: '123',
+                    vault: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.ListDocuments, {
+                    storageCredentials: uuidv4(),
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.ListDocuments, {
+                    storageCredentials: localStorage.id,
+                    vault: uuidv4(),
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Throws no document exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.ListDocuments, {
+                    storageCredentials: localStorage.id,
+                    vault: emptyLocalVaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.documents).toEqual([]);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Returns correct document data when exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.ListDocuments, {
+                    storageCredentials: localStorage.id,
+                    vault: testableLocalVaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.documents).toEqual([{
+                    name: "test.png",
+                }]);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('VerifyVault', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.VerifyVault, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vault']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.VerifyVault, {
+                    storageCredentials: '123',
+                    vault: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.VerifyVault, {
+                    storageCredentials: uuidv4(),
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.VerifyVault, {
+                    storageCredentials: localStorage.id,
+                    vault: uuidv4(),
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Returns vault verification boolean`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.VerifyVault, {
+                    storageCredentials: localStorage.id,
+                    vault: testableLocalVaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.verified).toBeTruthy();
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('GetHistoricalShipmentData', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'date']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                    date: DATE_1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates Date parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: 'Jan 1st, 2018',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidDateParams(caughtError, ['date']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                    date: DATE_1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                    date: DATE_1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Throws when no data exists for date`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: emptyLocalVaultId,
+                    date: DATE_0,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`No data found for date`);
+            }
+        }));
+
+        it(`Returns latest data when exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_2,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    on_date: DATE_1,
+                    shipment: {
+                        id: knownShipmentSchemaId,
+                        version: '0.0.1',
+                    },
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Returns intermediate data when exists`, mochaAsync(async () => {
+            try {
+                // Add new data at DATE_3
+                mockDate(DATE_3);
+                await CallRPCMethod(RPCVault.AddShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    shipment: {
+                        id: knownShipmentSchemaId,
+                        version: '0.0.2',
+                    },
+                });
+                resetDate(); // <-- Very important!
+
+                // Check data at DATE_2 is still previous data
+                let result: any = await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_2,
+                });
+
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    on_date: DATE_1,
+                    shipment: {
+                        id: knownShipmentSchemaId,
+                        version: '0.0.1',
+                    },
+                });
+
+                // Check data at DATE_4 is most recent
+                result = await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_4,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    on_date: DATE_3,
+                    shipment: {
+                        id: knownShipmentSchemaId,
+                        version: '0.0.2',
+                    },
+                });
             } catch (err) {
                 fail(`Should not have thrown [${err}]`);
             }

--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -1,0 +1,180 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+
+require('../../src/__tests__/testLoggingConfig');
+
+import 'mocha';
+import * as typeorm from "typeorm";
+import {
+    mochaAsync,
+    expectMissingRequiredParams,
+    expectInvalidUUIDParams,
+    cleanupEntities,
+    CallRPCMethod,
+} from "./utils";
+
+import { RPCVault } from '../vault';
+import { uuidv4 } from "../../src/utils";
+import { StorageCredential } from "../../src/entity/StorageCredential";
+import { Wallet } from "../../src/entity/Wallet";
+import { PrivateKeyDBFieldEncryption } from "../../src/entity/encryption/PrivateKeyDBFieldEncryption";
+
+export const RPCVaultTests = async function() {
+
+    let fullWallet1;
+    let fullWallet2;
+    let localStorage;
+
+    let testableVaultId;
+
+    beforeAll(async () => {
+        Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
+
+        // Import known funded wallets
+        fullWallet1 = await Wallet.import_entity('0x0000000000000000000000000000000000000000000000000000000000000001');
+        await fullWallet1.save();
+        fullWallet2 = await Wallet.import_entity('0x0000000000000000000000000000000000000000000000000000000000000002');
+        await fullWallet2.save();
+
+        localStorage = await StorageCredential.generate_entity({
+            title: 'local',
+            driver_type: 'local',
+        });
+        await localStorage.save();
+
+    });
+
+    afterAll(async() => {
+        await cleanupEntities(typeorm);
+    });
+
+    describe('CreateVault', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.CreateVault, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'shipperWallet']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.CreateVault, {
+                    storageCredentials: '123',
+                    shipperWallet: '123',
+                    carrierWallet: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'shipperWallet', 'carrierWallet']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.CreateVault, {
+                    storageCredentials: '123',
+                    shipperWallet: '123',
+                    carrierWallet: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'shipperWallet', 'carrierWallet']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.CreateVault, {
+                    storageCredentials: uuidv4(),
+                    shipperWallet: fullWallet1.id,
+                    carrierWallet: fullWallet2.id,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Shipper exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.CreateVault, {
+                    storageCredentials: localStorage.id,
+                    shipperWallet: uuidv4(),
+                    carrierWallet: fullWallet2.id,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Validates Carrier exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.CreateVault, {
+                    storageCredentials: localStorage.id,
+                    shipperWallet: fullWallet1.id,
+                    carrierWallet: uuidv4(),
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('Wallet not found');
+            }
+        }));
+
+        it(`Returns new Vault`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.CreateVault, {
+                    storageCredentials: localStorage.id,
+                    shipperWallet: fullWallet1.id,
+                    carrierWallet: fullWallet2.id,
+                });
+
+                expect(result.success).toBeTruthy();
+                expect(result.vault_id).toBeDefined();
+                expect(result.vault_signed).toBeDefined();
+                expect(result.vault_signed.author).toEqual(fullWallet1.public_key);
+                expect(result.vault_signed.hash).toBeDefined();
+                expect(result.vault_signed.at).toBeDefined();
+                expect(result.vault_signed.signature).toBeDefined();
+                expect(result.vault_signed.alg).toEqual('sha256');
+                expect(result.vault_uri).toBeDefined();
+
+                // Save this vault_id for use in later tests
+                testableVaultId = result.vault_id;
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+};

--- a/rpc/__tests__/wallet.ts
+++ b/rpc/__tests__/wallet.ts
@@ -1,0 +1,184 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+require('../../src/__tests__/testLoggingConfig');
+
+import 'mocha';
+import * as typeorm from "typeorm";
+import {
+    mochaAsync,
+    expectMissingRequiredParams,
+    expectInvalidUUIDParams,
+    CallRPCMethod,
+    cleanupDeployedContracts
+} from "./utils";
+
+import { RPCWallet } from '../wallet';
+import { loadContractFixtures } from "../contracts";
+import { Wallet } from "../../src/entity/Wallet";
+import { PrivateKeyDBFieldEncryption } from "../../src/entity/encryption/PrivateKeyDBFieldEncryption";
+
+describe('RPC Wallets', function() {
+
+    beforeAll(async () => {
+        // read connection options from ormconfig file (or ENV variables)
+        const connectionOptions = await typeorm.getConnectionOptions();
+        await typeorm.createConnection({
+            ...connectionOptions,
+        });
+        Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
+        await loadContractFixtures();
+    });
+
+    afterAll(async() => {
+        await cleanupDeployedContracts(typeorm);
+    });
+
+    describe('Create', function() {
+        it(`Requires no parameters`, mochaAsync(async () => {
+            const initialCount = await Wallet.count();
+
+            try {
+                const response: any = await CallRPCMethod(RPCWallet.Create, null);
+                expect(response.success).toBeTruthy();
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await Wallet.count()).toEqual(initialCount + 1);
+        }));
+    });
+
+    describe('Import', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+            const initialCount = await Wallet.count();
+
+            try {
+                await RPCWallet.Import({});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['privateKey']);
+            expect(await Wallet.count()).toEqual(initialCount);
+        }));
+
+        it(`Validates PrivateKey format`, mochaAsync(async () => {
+            const initialCount = await Wallet.count();
+
+            try {
+                await CallRPCMethod(RPCWallet.Import,{
+                    privateKey: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual('private key length is invalid');
+            }
+
+            expect(await Wallet.count()).toEqual(initialCount);
+        }));
+
+        it(`Generates correct wallet`, mochaAsync(async () => {
+            const initialCount = await Wallet.count();
+
+            try {
+                const response: any = await CallRPCMethod(RPCWallet.Import,{
+                    privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+                });
+                expect(response.success).toBeTruthy();
+                expect(response.wallet.address).toEqual('0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf');
+                expect(response.wallet.public_key).toEqual('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8');
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await Wallet.count()).toEqual(initialCount + 1);
+        }));
+    });
+
+    describe('List', function() {
+        it(`Requires no parameters`, mochaAsync(async () => {
+            const initialCount = await Wallet.count();
+
+            try {
+                const response: any = await CallRPCMethod(RPCWallet.List, null);
+                expect(response.success).toBeTruthy();
+                expect(response.wallets.length).toEqual(initialCount);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await Wallet.count()).toEqual(initialCount);
+        }));
+    });
+
+    describe('Balance', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCWallet.Balance, null);
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['wallet']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCWallet.Balance, {
+                    wallet: '123'
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['wallet']);
+        }));
+
+        it(`Returns correct Balance`, mochaAsync(async () => {
+            const initialCount = await Wallet.count();
+
+            try {
+                // Get existing wallet
+                const imported: any = await CallRPCMethod(RPCWallet.Import,{
+                    privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+                });
+
+                const response: any = await CallRPCMethod(RPCWallet.Balance,{
+                    wallet: imported.wallet.id,
+                });
+                expect(response.success).toBeTruthy();
+                expect(response.ether).toEqual('158456325028528675187087900672');
+                expect(response.ship).toEqual('0');
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+
+            expect(await Wallet.count()).toEqual(initialCount);
+        }));
+    });
+
+});

--- a/rpc/__tests__/wallet.ts
+++ b/rpc/__tests__/wallet.ts
@@ -24,29 +24,22 @@ import {
     mochaAsync,
     expectMissingRequiredParams,
     expectInvalidUUIDParams,
+    cleanupEntities,
     CallRPCMethod,
-    cleanupDeployedContracts
 } from "./utils";
 
 import { RPCWallet } from '../wallet';
-import { loadContractFixtures } from "../contracts";
 import { Wallet } from "../../src/entity/Wallet";
 import { PrivateKeyDBFieldEncryption } from "../../src/entity/encryption/PrivateKeyDBFieldEncryption";
 
-describe('RPC Wallets', function() {
+export const RPCWalletTests = async function() {
 
     beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
         Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
-        await loadContractFixtures();
     });
 
     afterAll(async() => {
-        await cleanupDeployedContracts(typeorm);
+        await cleanupEntities(typeorm);
     });
 
     describe('Create', function() {
@@ -100,11 +93,11 @@ describe('RPC Wallets', function() {
 
             try {
                 const response: any = await CallRPCMethod(RPCWallet.Import,{
-                    privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
+                    privateKey: '0x0000000000000000000000000000000000000000000000000000000000000111',
                 });
                 expect(response.success).toBeTruthy();
-                expect(response.wallet.address).toEqual('0x7E5F4552091A69125d5DfCb7b8C2659029395Bdf');
-                expect(response.wallet.public_key).toEqual('79be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798483ada7726a3c4655da4fbfc0e1108a8fd17b448a68554199c47d08ffb10d4b8');
+                expect(response.wallet.address).toEqual('0x718811e2d1170db844d0c5de6D276b299f2916a9');
+                expect(response.wallet.public_key).toEqual('64e1b1969f9102977691a40431b0b672055dcf31163897d996434420e6c95dc9c16f60c7c11fc3c9eb27fa26a9035b669bfb77d21cef371ddce94e329222550c');
             } catch (err) {
                 fail(`Should not have thrown [${err}]`);
             }
@@ -162,7 +155,7 @@ describe('RPC Wallets', function() {
             const initialCount = await Wallet.count();
 
             try {
-                // Get existing wallet
+                // Import new (known) wallet
                 const imported: any = await CallRPCMethod(RPCWallet.Import,{
                     privateKey: '0x0000000000000000000000000000000000000000000000000000000000000001',
                 });
@@ -171,14 +164,14 @@ describe('RPC Wallets', function() {
                     wallet: imported.wallet.id,
                 });
                 expect(response.success).toBeTruthy();
-                expect(response.ether).toEqual('158456325028528675187087900672');
+                expect(response.ether).toEqual('158456325028527357987087900672');
                 expect(response.ship).toEqual('0');
             } catch (err) {
                 fail(`Should not have thrown [${err}]`);
             }
 
-            expect(await Wallet.count()).toEqual(initialCount);
+            expect(await Wallet.count()).toEqual(initialCount + 1);
         }));
     });
 
-});
+};

--- a/rpc/__tests__/wallet.ts
+++ b/rpc/__tests__/wallet.ts
@@ -70,7 +70,7 @@ describe('RPC Wallets', function() {
             const initialCount = await Wallet.count();
 
             try {
-                await RPCWallet.Import({});
+                await CallRPCMethod(RPCWallet.Import,{});
                 fail("Did not Throw"); return;
             } catch (err) {
                 caughtError = err;

--- a/rpc/contracts.ts
+++ b/rpc/contracts.ts
@@ -96,6 +96,10 @@ export class LoadedContracts {
             return this.contracts[project][version].contract;
         }
     }
+
+    public reset(): void {
+        this.contracts = {};
+    }
 }
 
 async function getNetwork(contractMetaData) {

--- a/rpc/decorators.ts
+++ b/rpc/decorators.ts
@@ -46,6 +46,7 @@ class RPCMethodOptions {
 class RPCMethodValidateOptions {
     uuid?: string[];
     string?: string[];
+    object?: string[];
 }
 
 export function RPCMethod(options?: RPCMethodOptions) {
@@ -142,5 +143,25 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
 
     if (failed.length > 0) {
         throw new rpc.Error.InvalidParams(`Invalid String${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
+    }
+
+    if (validations && validations.object) {
+        for (let param of validations.object) {
+            if (args && args.hasOwnProperty(param)) {
+                if (typeof args[param] !== 'object' || Array.isArray(args[param])) {
+                    failed.push(param);
+                } else {
+                    try {
+                        JSON.stringify(args[param]);
+                    } catch (err) {
+                        failed.push(param);
+                    }
+                }
+            }
+        }
+    }
+
+    if (failed.length > 0) {
+        throw new rpc.Error.InvalidParams(`Invalid Object${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
     }
 }

--- a/rpc/decorators.ts
+++ b/rpc/decorators.ts
@@ -45,6 +45,7 @@ class RPCMethodOptions {
 
 class RPCMethodValidateOptions {
     uuid?: string[];
+    string?: string[];
 }
 
 export function RPCMethod(options?: RPCMethodOptions) {
@@ -129,5 +130,17 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
 
     if (failed.length > 0) {
         throw new rpc.Error.InvalidParams(`Invalid UUID${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
+    }
+
+    if (validations && validations.string) {
+        for (let param of validations.string) {
+            if (args && args.hasOwnProperty(param) && !(typeof args[param] === 'string')) {
+                failed.push(param);
+            }
+        }
+    }
+
+    if (failed.length > 0) {
+        throw new rpc.Error.InvalidParams(`Invalid String${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
     }
 }

--- a/rpc/event.ts
+++ b/rpc/event.ts
@@ -27,9 +27,10 @@ const metrics = MetricsReporter.Instance;
 export class RPCEvent {
     @RPCMethod({ require: ['url', 'project'] })
     public static async Subscribe(args) {
+        const project = loadedContracts.get(args.project);
         const eventSubscription = await EventSubscription.getOrCreate(args);
 
-        await eventSubscription.start(loadedContracts.get(eventSubscription.project).getContractEntity());
+        await eventSubscription.start(project.getContractEntity());
 
         // This should be non-blocking
         EventSubscription.getCount()

--- a/rpc/storage_credentials.ts
+++ b/rpc/storage_credentials.ts
@@ -51,7 +51,12 @@ export class RPCStorageCredentials {
         };
     }
 
-    @RPCMethod({ require: ['title', 'driver_type'] })
+    @RPCMethod({
+        require: ['title', 'driver_type'],
+        validate: {
+            string: ['title'],
+        },
+    })
     public static async Create(args) {
         // Local driver type is disabled in environment other than LOCAL
         // and storage credentials creation is disabled for unrecognizable driver type
@@ -128,7 +133,12 @@ export class RPCStorageCredentials {
         return await RPCStorageCredentials._test_credentials(testOptions);
     }
 
-    @RPCMethod({ require: ['title', 'driver_type'] })
+    @RPCMethod({
+        require: ['title', 'driver_type'],
+        validate: {
+            string: ['title'],
+        },
+    })
     public static async TestAndStore(args) {
         // Local driver type is disabled in environment other than LOCAL
         // and storage credentials creation is disabled for unrecognizable driver type
@@ -155,6 +165,7 @@ export class RPCStorageCredentials {
         require: ['storageCredentials'],
         validate: {
             uuid: ['storageCredentials'],
+            string: ['title'],
         },
     })
     public static async Update(args) {

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import S3 = require('aws-sdk/clients/s3');
+const AWS = require('aws-sdk');
 
 import { Wallet } from '../src/entity/Wallet';
 import { LoadVault } from '../src/shipchain/LoadVault';
@@ -194,12 +194,12 @@ export class RPCVault {
         },
     })
     public static async AddDocumentFromS3(args) {
-        const documentContent = await RPCVault.getFileFromS3(args.bucket, args.key);
-
         const storage = await StorageCredential.getOptionsById(args.storageCredentials);
         const wallet = await Wallet.getById(args.vaultWallet);
 
         const load = new LoadVault(storage, args.vault);
+
+        const documentContent = await RPCVault.getFileFromS3(args.bucket, args.key);
 
         await load.addDocument(wallet, args.documentName, documentContent);
         const signature = await load.writeMetadata(wallet);
@@ -242,7 +242,7 @@ export class RPCVault {
 
     static async getFileFromS3(bucket: string, objectKey: string): Promise<string> {
         let s3_options = { apiVersion: '2006-03-01' };
-        const s3 = new S3(s3_options);
+        const s3 = new AWS.S3(s3_options);
 
         return new Promise<string>((resolve, reject) => {
             s3.getObject(
@@ -280,7 +280,7 @@ export class RPCVault {
         contentType: string = 'application/octet-stream',
     ): Promise<string> {
         let s3_options = { apiVersion: '2006-03-01' };
-        const s3 = new S3(s3_options);
+        const s3 = new AWS.S3(s3_options);
 
         return new Promise<string>((resolve, reject) => {
             s3.upload(

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -190,6 +190,7 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'documentName', 'key', 'bucket'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            string: ['documentName', 'key', 'bucket'],
         },
     })
     public static async AddDocumentFromS3(args) {
@@ -213,6 +214,7 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'documentName', 'key', 'bucket'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            string: ['documentName', 'key', 'bucket'],
         },
     })
     public static async PutDocumentInS3(args) {
@@ -387,6 +389,7 @@ export class RPCVault {
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
             date: ['date'],
+            string: ['documentName'],
         },
     })
     public static async GetHistoricalDocument(args) {

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -79,15 +79,12 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'payload'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            object: ['payload'],
         },
     })
     public static async AddTrackingData(args) {
         const storage = await StorageCredential.getOptionsById(args.storageCredentials);
         const wallet = await Wallet.getById(args.vaultWallet);
-
-        if (args.payload == '') {
-            throw new Error('Invalid Payload provided');
-        }
 
         const load = new LoadVault(storage, args.vault);
 
@@ -125,6 +122,7 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'shipment'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            object: ['shipment'],
         },
     })
     public static async AddShipmentData(args) {
@@ -148,6 +146,7 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'documentName'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            string: ['documentName'],
         },
     })
     public static async GetDocument(args) {
@@ -169,6 +168,7 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'documentName', 'documentContent'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            string: ['documentName', 'documentContent'],
         },
     })
     public static async AddDocument(args) {
@@ -342,6 +342,7 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            date: ['date'],
         },
     })
     public static async GetHistoricalShipmentData(args) {
@@ -363,6 +364,7 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            date: ['date'],
         },
     })
     public static async GetHistoricalTrackingData(args) {
@@ -384,6 +386,7 @@ export class RPCVault {
         require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            date: ['date'],
         },
     })
     public static async GetHistoricalDocument(args) {

--- a/src/__tests__/contracts.ts
+++ b/src/__tests__/contracts.ts
@@ -17,7 +17,6 @@
 require('./testLoggingConfig');
 
 import 'mocha';
-import * as typeorm from "typeorm";
 import { Wallet } from '../entity/Wallet';
 import { Contract, Version, Project, Network } from '../entity/Contract';
 import { PrivateKeyDBFieldEncryption } from "../entity/encryption/PrivateKeyDBFieldEncryption";
@@ -29,14 +28,9 @@ const LATEST_SHIPTOKEN = "1.0.0";
 const LATEST_LOAD = "1.1.0";
 
 
-describe('ContractEntity', function() {
+export const ContractEntityTests = async function() {
 
     beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
         Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
     });
 
@@ -85,4 +79,4 @@ describe('ContractEntity', function() {
         },
         10000,
     );
-});
+};

--- a/src/__tests__/credentials.ts
+++ b/src/__tests__/credentials.ts
@@ -20,15 +20,7 @@ import 'mocha';
 import * as typeorm from "typeorm";
 import { StorageCredential } from '../entity/StorageCredential';
 
-describe('StorageCredentialEntity', function() {
-
-    beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
-    });
+export const StorageCredentialEntityTests = async function() {
 
     it(`can create and retrieve storage credentials`, async () => {
         const DB = typeorm.getConnection();
@@ -75,4 +67,4 @@ describe('StorageCredentialEntity', function() {
         expect(credential.title).toEqual(newTitle);
         expect(credential.options).toEqual(newOptions);
     });
-});
+};

--- a/src/__tests__/eventsubscriptions.ts
+++ b/src/__tests__/eventsubscriptions.ts
@@ -17,7 +17,6 @@
 require('./testLoggingConfig');
 
 import 'mocha';
-import * as typeorm from "typeorm";
 import { Wallet } from '../entity/Wallet';
 import { Project } from '../entity/Contract';
 import { EventSubscription, EventSubscriberAttrs } from '../entity/EventSubscription';
@@ -55,14 +54,10 @@ function AsyncGetJSON(url) {
 }
 
 
-describe('EventSubscriptionEntity', function() {
+export const EventSubscriptionEntityTests = async  function() {
 
     beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
+
         Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
     });
 
@@ -150,4 +145,4 @@ describe('EventSubscriptionEntity', function() {
         },
         30000, // This one can be a bit slow...
     );
-});
+};

--- a/src/__tests__/storage.ts
+++ b/src/__tests__/storage.ts
@@ -154,7 +154,7 @@ const fileConfigs = {
 
 const emptyDirectoryListing = new DirectoryListing('.');
 
-describe('StorageDriver ', function() {
+export const StorageDriverTests = async function() {
     // Create and Cleanup the local testing directory
     // ==============================================
     beforeAll(() => {
@@ -416,4 +416,4 @@ describe('StorageDriver ', function() {
             });
         });
     });
-});
+};

--- a/src/__tests__/storage.ts
+++ b/src/__tests__/storage.ts
@@ -195,10 +195,10 @@ export const StorageDriverTests = async function() {
             it(
                 `can list the empty vault directory`,
                 mochaAsync(async () => {
-                    let result = await storageDriver.listDirectory();
+                    let result = await storageDriver.listDirectory(null, null, false);
                     expect(result).toEqual(emptyDirectoryListing);
 
-                    result = await storageDriver.listDirectory(null, true);
+                    result = await storageDriver.listDirectory(null, true, false);
                     expect(result).toEqual(emptyDirectoryListing);
                 }),
             );

--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -33,7 +33,7 @@ const DATE_3 = '2018-01-01T01:00:03.000Z';
 const DATE_4 = '2018-01-01T01:00:04.000Z';
 const DATE_5 = '2018-01-01T01:00:05.000Z';
 
-describe('Vaults', function() {
+export const VaultTests = async function() {
     const RealDate = Date;
 
     function mockDate(isoDate) {
@@ -816,4 +816,4 @@ describe('Vaults', function() {
         expect(test_4[CONTAINER][FILE_2]).toEqual("2-4");
     });
 
-});
+};

--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -20,6 +20,7 @@ import 'mocha';
 import { Vault } from '../vaults/Vault';
 import { Wallet } from '../entity/Wallet';
 import { PrivateKeyDBFieldEncryption } from "../entity/encryption/PrivateKeyDBFieldEncryption";
+import { CloseConnection } from "../redis";
 
 const storage_driver = { driver_type: 'local', base_path: 'storage/vault-tests' };
 const CONTAINER = 'test2';
@@ -67,6 +68,10 @@ describe('Vaults', function() {
 
     afterEach(async () => {
         global.Date = RealDate;
+    });
+
+    afterAll(async () => {
+        CloseConnection();
     });
 
     it(`can create or load an empty vault`, async () => {

--- a/src/__tests__/wallets.ts
+++ b/src/__tests__/wallets.ts
@@ -23,14 +23,9 @@ import { PrivateKeyDBFieldEncryption } from "../entity/encryption/PrivateKeyDBFi
 
 import EthCrypto from 'eth-crypto';
 
-describe('WalletEntity', function() {
+export const WalletEntityTests = async function() {
 
     beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
         Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
     });
 
@@ -98,4 +93,4 @@ describe('WalletEntity', function() {
 
         expect(Wallet.recover_signer_public_key(signed, hash)).toEqual(wallet.public_key);
     });
-});
+};

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -29,7 +29,7 @@ let redisClient = null;
 let redlock = null;
 
 function getRedlock() {
-    if(!redlock || !redisClient) {
+    if (!redlock || !redisClient) {
         redisClient = redis.createClient(REDIS_URL);
 
         redlock = new Redlock([redisClient], {
@@ -93,7 +93,9 @@ export async function ResourceLock(
 }
 
 export const CloseConnection = (callback?) => {
-    redisClient.quit(callback);
+    if (redisClient) {
+        redisClient.quit(callback);
+    }
     redisClient = null;
     redlock = null;
 };

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -85,3 +85,7 @@ export async function ResourceLock(
             });
     });
 }
+
+export const CloseConnection = (callback?) => {
+    redisClient.quit(callback);
+};

--- a/src/shipchain/__tests__/loadvault.ts
+++ b/src/shipchain/__tests__/loadvault.ts
@@ -17,7 +17,6 @@
 require('../../__tests__/testLoggingConfig');
 
 import 'mocha';
-import * as typeorm from "typeorm";
 import { LoadVault } from '../LoadVault';
 import { Wallet } from '../../entity/Wallet';
 import { PrivateKeyDBFieldEncryption } from "../../entity/encryption/PrivateKeyDBFieldEncryption";
@@ -26,7 +25,7 @@ import { CloseConnection } from "../../redis";
 const storage_driver = { driver_type: 'local', base_path: 'storage/vault-tests' };
 
 
-describe('LoadVault', function() {
+export const LoadVaultTests = async function() {
     const RealDate = Date;
 
     function mockDate(isoDate) {
@@ -45,12 +44,6 @@ describe('LoadVault', function() {
     }
 
     beforeAll(async () => {
-        // read connection options from ormconfig file (or ENV variables)
-        const connectionOptions = await typeorm.getConnectionOptions();
-        await typeorm.createConnection({
-            ...connectionOptions,
-        });
-
         Wallet.setPrivateKeyEncryptionHandler(await PrivateKeyDBFieldEncryption.getInstance());
     });
 
@@ -160,7 +153,7 @@ describe('LoadVault', function() {
         expect(listing).toEqual([{name: DOCUMENT_01.name},{name: DOCUMENT_02.name}]);
     });
 
-});
+};
 
 
 const SHIPMENT_01 = {

--- a/src/shipchain/__tests__/loadvault.ts
+++ b/src/shipchain/__tests__/loadvault.ts
@@ -21,6 +21,7 @@ import * as typeorm from "typeorm";
 import { LoadVault } from '../LoadVault';
 import { Wallet } from '../../entity/Wallet';
 import { PrivateKeyDBFieldEncryption } from "../../entity/encryption/PrivateKeyDBFieldEncryption";
+import { CloseConnection } from "../../redis";
 
 const storage_driver = { driver_type: 'local', base_path: 'storage/vault-tests' };
 
@@ -55,6 +56,10 @@ describe('LoadVault', function() {
 
     afterEach(async () => {
         resetDate();
+    });
+
+    afterAll(async () => {
+        CloseConnection();
     });
 
     it(`can be created`, async () => {

--- a/src/storage/StorageDriver.ts
+++ b/src/storage/StorageDriver.ts
@@ -69,7 +69,7 @@ export abstract class StorageDriver {
 
     abstract async fileExists(filePath: string): Promise<any>;
 
-    abstract async listDirectory(vaultDirectory: string, recursive?: boolean): Promise<any>;
+    abstract async listDirectory(vaultDirectory: string, recursive?: boolean, errorOnEmpty?: boolean): Promise<any>;
 }
 
 enum DriverErrorStates {

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -304,8 +304,8 @@ export class Vault {
         return await ResourceLock(this.id, this.driver, 'removeDirectory', [directoryPath, recursive]);
     }
 
-    async listDirectory(vaultDirectory: string, recursive?: boolean) {
-        return await ResourceLock(this.id, this.driver, 'listDirectory', [vaultDirectory, recursive]);
+    async listDirectory(vaultDirectory: string, recursive?: boolean, errorOnEmpty?: boolean) {
+        return await ResourceLock(this.id, this.driver, 'listDirectory', [vaultDirectory, recursive, errorOnEmpty]);
     }
 
     getOrCreateContainer(author: Wallet, name: string, container_type?: string, meta?: any) {
@@ -912,7 +912,7 @@ export class ExternalFileMultiContainer extends ExternalDirectoryContainer imple
     }
 
     async listFiles() {
-        const fileList = (await this.vault.listDirectory(this.name)).files;
+        const fileList = (await this.vault.listDirectory(this.name, null, false)).files;
         for (let file of fileList) {
             file.name = file.name.replace(/.json$/, '');
         }


### PR DESCRIPTION
Until now, Engine did not have any unit tests focusing on the exposed RPC methods.  This adds unit tests focusing on RPC Methods including some enhanced parameter validations and standardized error responses.

Due to some of the CRUD operations spanning across individual tests, the tests need to be run in sequence.  To achieve a consistent test order, Jest now runs a single test script `jest.testOrder.ts` that includes all test spec files.

Additionally, as more tests are reliant on the included services (such as the Geth POA network), the `--runInBand` option is being provided to Jest to prevent parallel execution.  Without this option, some expected responses of the included services are not consistent as we cannot control when specific tests run.