### PR TITLE
GasPriceOracle needs to handle outliers from EthGasStation

### DIFF
--- a/src/__tests__/gaspriceoracle.ts
+++ b/src/__tests__/gaspriceoracle.ts
@@ -42,6 +42,7 @@ export const GasPriceOracleTests = async function() {
 
         nock('https://ethgasstation.info')
             .get('/json/ethgasAPI.json')
+            .times(3)
             .reply(200, {
                 fast: 500,
                 fastest: 600,
@@ -65,6 +66,7 @@ export const GasPriceOracleTests = async function() {
 
         nock('https://ethgasstation.info')
             .get('/json/ethgasAPI.json')
+            .times(3)
             .reply(200, {
                 fast: 500,
                 fastest: 600,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,3 +82,7 @@ export function verifySignature(signed) {
 export function verifyHash(obj) {
     return objectHash(obj, obj.signed.at, obj.signed.alg) == obj.signed.hash;
 }
+
+export function delay(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
After letting this collect more data overnight, there were some irregularities (spikes) in gas prices that the GasPriceOracle does not gracefully handle.  This change to pull multiple values and select one with the lower estimate should help lessen the impact on the gas prices Engine uses for transactions.  Additionally, the previous gas price value is being used in a stepping calculation to more gradually raise the gas prices if there is a prolonged period of high prices.