### PR TITLE
Batch events

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ Currently Engine supports connection to vaults in Local Storage, S3 Buckets (or 
 These parameters are common to all Storage Credential creations:
 
  - `driver_type` One of `s3`, `sftp`, or `local`.  These may have additional parameters described below.
- - `title` Friendly title to remeber this connection by.
+ - `title` Friendly title to remember this connection by.
  - `base_path` Path within the storage driver where the vaults will be created.  Defaults to the root directory.
 
 ##### S3
@@ -568,7 +568,7 @@ A vault's contents can be verified against the embedded, signed hash to ensure t
 }
 ```
 
-The object returned will include the newly created `vault_id`.  This value will need to be provided as the `vault` parameter to all remaining interactions with the Vault (as seen in the examples below).
+The object returned will include a boolean `verified` dependent on the verification of the data.
 
 #### Tracking Data Container
 

--- a/jest.testOrder.ts
+++ b/jest.testOrder.ts
@@ -42,43 +42,45 @@ import { StorageDriverTests } from './src/__tests__/storage';
 import { VaultTests } from './src/__tests__/vaults';
 import { WalletEntityTests } from './src/__tests__/wallets';
 import { GasPriceOracleTests } from "./src/__tests__/gaspriceoracle";
+import { EventSubscriptionPostsTests } from "./src/__tests__/eventSubscriptionPosts";
+
 
 // ShipChain Tests
 // ===============
 import { LoadVaultTests } from './src/shipchain/__tests__/loadvault';
 
 
-describe('RPC', async () => {
-
-    beforeAll(async () => {
-        try {
-            // read connection options from ormconfig file (or ENV variables)
-            const connectionOptions = await typeorm.getConnectionOptions();
-            await typeorm.createConnection(connectionOptions);
-            await loadContractFixtures();
-        } catch(err){
-            console.error(`beforeAll Error ${err}`);
-        }
-    }, 10000);
-
-    afterAll(async() => {
-        try {
-            await cleanupDeployedContracts(typeorm);
-            let conn = await typeorm.getConnection();
-            await conn.close();
-            await CloseRedis();
-        } catch(err){
-            console.error(`afterAll Error ${err}`);
-        }
-    }, 10000);
-
-    describe('Events', RPCEventTests);
-    describe('Vaults', RPCVaultTests);
-    describe('Storage', RPCStorageCredentialsTests);
-    describe('Transactions', RPCTransactions);
-    describe('Wallets', RPCWalletTests);
-
-});
+// describe('RPC', async () => {
+//
+//     beforeAll(async () => {
+//         try {
+//             // read connection options from ormconfig file (or ENV variables)
+//             const connectionOptions = await typeorm.getConnectionOptions();
+//             await typeorm.createConnection(connectionOptions);
+//             await loadContractFixtures();
+//         } catch(err){
+//             console.error(`beforeAll Error ${err}`);
+//         }
+//     }, 10000);
+//
+//     afterAll(async() => {
+//         try {
+//             await cleanupDeployedContracts(typeorm);
+//             let conn = await typeorm.getConnection();
+//             await conn.close();
+//             await CloseRedis();
+//         } catch(err){
+//             console.error(`afterAll Error ${err}`);
+//         }
+//     }, 10000);
+//
+//     describe('Events', RPCEventTests);
+//     describe('Vaults', RPCVaultTests);
+//     describe('Storage', RPCStorageCredentialsTests);
+//     describe('Transactions', RPCTransactions);
+//     describe('Wallets', RPCWalletTests);
+//
+// });
 
 describe('Core', async () => {
     beforeAll(async () => {
@@ -102,38 +104,39 @@ describe('Core', async () => {
         }
     }, 10000);
 
-    describe('Contracts', ContractEntityTests);
-    describe('StorageCredentials', StorageCredentialEntityTests);
-    describe('EventSubscriptions', EventSubscriptionEntityTests);
-    describe('StorageDriver', StorageDriverTests);
-    describe('Vaults', VaultTests);
-    describe('Wallets', WalletEntityTests);
-    describe('GasPriceOracle', GasPriceOracleTests);
+    // describe('Contracts', ContractEntityTests);
+    // describe('StorageCredentials', StorageCredentialEntityTests);
+    // describe('EventSubscriptions', EventSubscriptionEntityTests);
+    // describe('StorageDriver', StorageDriverTests);
+    // describe('Vaults', VaultTests);
+    // describe('Wallets', WalletEntityTests);
+    // describe('GasPriceOracle', GasPriceOracleTests);
+    describe('EventSubscriptionPosts', EventSubscriptionPostsTests);
 
 });
 
-describe('ShipChain', async () => {
-    beforeAll(async () => {
-        try {
-            // read connection options from ormconfig file (or ENV variables)
-            const connectionOptions = await typeorm.getConnectionOptions();
-            await typeorm.createConnection(connectionOptions);
-        } catch(err){
-            console.error(`beforeAll Error ${err}`);
-        }
-    }, 10000);
-
-    afterAll(async() => {
-        try {
-            await cleanupDeployedContracts(typeorm);
-            let conn = await typeorm.getConnection();
-            await conn.close();
-            await CloseRedis();
-        } catch(err){
-            console.error(`afterAll Error ${err}`);
-        }
-    }, 10000);
-
-    describe('LOAD Vault', LoadVaultTests);
-
-});
+// describe('ShipChain', async () => {
+//     beforeAll(async () => {
+//         try {
+//             // read connection options from ormconfig file (or ENV variables)
+//             const connectionOptions = await typeorm.getConnectionOptions();
+//             await typeorm.createConnection(connectionOptions);
+//         } catch(err){
+//             console.error(`beforeAll Error ${err}`);
+//         }
+//     }, 10000);
+//
+//     afterAll(async() => {
+//         try {
+//             await cleanupDeployedContracts(typeorm);
+//             let conn = await typeorm.getConnection();
+//             await conn.close();
+//             await CloseRedis();
+//         } catch(err){
+//             console.error(`afterAll Error ${err}`);
+//         }
+//     }, 10000);
+//
+//     describe('LOAD Vault', LoadVaultTests);
+//
+// });

--- a/jest.testOrder.ts
+++ b/jest.testOrder.ts
@@ -43,6 +43,7 @@ import { VaultTests } from './src/__tests__/vaults';
 import { WalletEntityTests } from './src/__tests__/wallets';
 import { GasPriceOracleTests } from "./src/__tests__/gaspriceoracle";
 import { EventSubscriptionPostsTests } from "./src/__tests__/eventSubscriptionPosts";
+import { UtilsTests } from "./src/__tests__/utils";
 
 
 // ShipChain Tests
@@ -50,37 +51,37 @@ import { EventSubscriptionPostsTests } from "./src/__tests__/eventSubscriptionPo
 import { LoadVaultTests } from './src/shipchain/__tests__/loadvault';
 
 
-// describe('RPC', async () => {
-//
-//     beforeAll(async () => {
-//         try {
-//             // read connection options from ormconfig file (or ENV variables)
-//             const connectionOptions = await typeorm.getConnectionOptions();
-//             await typeorm.createConnection(connectionOptions);
-//             await loadContractFixtures();
-//         } catch(err){
-//             console.error(`beforeAll Error ${err}`);
-//         }
-//     }, 10000);
-//
-//     afterAll(async() => {
-//         try {
-//             await cleanupDeployedContracts(typeorm);
-//             let conn = await typeorm.getConnection();
-//             await conn.close();
-//             await CloseRedis();
-//         } catch(err){
-//             console.error(`afterAll Error ${err}`);
-//         }
-//     }, 10000);
-//
-//     describe('Events', RPCEventTests);
-//     describe('Vaults', RPCVaultTests);
-//     describe('Storage', RPCStorageCredentialsTests);
-//     describe('Transactions', RPCTransactions);
-//     describe('Wallets', RPCWalletTests);
-//
-// });
+describe('RPC', async () => {
+
+    beforeAll(async () => {
+        try {
+            // read connection options from ormconfig file (or ENV variables)
+            const connectionOptions = await typeorm.getConnectionOptions();
+            await typeorm.createConnection(connectionOptions);
+            await loadContractFixtures();
+        } catch(err){
+            console.error(`beforeAll Error ${err}`);
+        }
+    }, 10000);
+
+    afterAll(async() => {
+        try {
+            await cleanupDeployedContracts(typeorm);
+            let conn = await typeorm.getConnection();
+            await conn.close();
+            await CloseRedis();
+        } catch(err){
+            console.error(`afterAll Error ${err}`);
+        }
+    }, 10000);
+
+    describe('Events', RPCEventTests);
+    describe('Vaults', RPCVaultTests);
+    describe('Storage', RPCStorageCredentialsTests);
+    describe('Transactions', RPCTransactions);
+    describe('Wallets', RPCWalletTests);
+
+});
 
 describe('Core', async () => {
     beforeAll(async () => {
@@ -104,39 +105,40 @@ describe('Core', async () => {
         }
     }, 10000);
 
-    // describe('Contracts', ContractEntityTests);
-    // describe('StorageCredentials', StorageCredentialEntityTests);
-    // describe('EventSubscriptions', EventSubscriptionEntityTests);
-    // describe('StorageDriver', StorageDriverTests);
-    // describe('Vaults', VaultTests);
-    // describe('Wallets', WalletEntityTests);
-    // describe('GasPriceOracle', GasPriceOracleTests);
+    describe('Contracts', ContractEntityTests);
+    describe('StorageCredentials', StorageCredentialEntityTests);
+    describe('EventSubscriptions', EventSubscriptionEntityTests);
+    describe('StorageDriver', StorageDriverTests);
+    describe('Vaults', VaultTests);
+    describe('Wallets', WalletEntityTests);
+    describe('GasPriceOracle', GasPriceOracleTests);
     describe('EventSubscriptionPosts', EventSubscriptionPostsTests);
+    describe('Utils', UtilsTests);
 
 });
 
-// describe('ShipChain', async () => {
-//     beforeAll(async () => {
-//         try {
-//             // read connection options from ormconfig file (or ENV variables)
-//             const connectionOptions = await typeorm.getConnectionOptions();
-//             await typeorm.createConnection(connectionOptions);
-//         } catch(err){
-//             console.error(`beforeAll Error ${err}`);
-//         }
-//     }, 10000);
-//
-//     afterAll(async() => {
-//         try {
-//             await cleanupDeployedContracts(typeorm);
-//             let conn = await typeorm.getConnection();
-//             await conn.close();
-//             await CloseRedis();
-//         } catch(err){
-//             console.error(`afterAll Error ${err}`);
-//         }
-//     }, 10000);
-//
-//     describe('LOAD Vault', LoadVaultTests);
-//
-// });
+describe('ShipChain', async () => {
+    beforeAll(async () => {
+        try {
+            // read connection options from ormconfig file (or ENV variables)
+            const connectionOptions = await typeorm.getConnectionOptions();
+            await typeorm.createConnection(connectionOptions);
+        } catch(err){
+            console.error(`beforeAll Error ${err}`);
+        }
+    }, 10000);
+
+    afterAll(async() => {
+        try {
+            await cleanupDeployedContracts(typeorm);
+            let conn = await typeorm.getConnection();
+            await conn.close();
+            await CloseRedis();
+        } catch(err){
+            console.error(`afterAll Error ${err}`);
+        }
+    }, 10000);
+
+    describe('LOAD Vault', LoadVaultTests);
+
+});

--- a/rpc/Engine.postman_collection.json
+++ b/rpc/Engine.postman_collection.json
@@ -843,7 +843,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"method\": \"load.get_historical_document\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"date\": \"2018-11-09T19:57:56.340Z\",\n\t\t\"documentName\": \"example.png\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+							"raw": "{\n\t\"method\": \"vault.get_historical_document\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"date\": \"2018-11-09T19:57:56.340Z\",\n\t\t\"documentName\": \"example.png\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
 						},
 						"url": {
 							"raw": "http://localhost:2000/",
@@ -871,7 +871,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"method\": \"load.get_historical_tracking_data\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"date\": \"2018-11-09T19:57:56.340Z\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+							"raw": "{\n\t\"method\": \"vault.get_historical_tracking_data\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"date\": \"2018-11-09T19:57:56.340Z\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
 						},
 						"url": {
 							"raw": "http://localhost:2000/",
@@ -899,7 +899,7 @@
 						],
 						"body": {
 							"mode": "raw",
-							"raw": "{\n\t\"method\": \"load.get_historical_shipment_data\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"date\": \"2018-11-09T19:57:56.340Z\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+							"raw": "{\n\t\"method\": \"vault.get_historical_shipment_data\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"date\": \"2018-11-09T19:57:56.340Z\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
 						},
 						"url": {
 							"raw": "http://localhost:2000/",

--- a/src/AsyncPoll.ts
+++ b/src/AsyncPoll.ts
@@ -42,6 +42,7 @@ export class AsyncPoll extends EventEmitter {
                 await callback();
             } catch (err) {
                 logger.error(`Error Executing AsyncPoll ${err}`);
+                logger.error(`Stack trace for error: ${err.stack}`);
             }
             if (!once) {
                 self.start();

--- a/src/AsyncPoll.ts
+++ b/src/AsyncPoll.ts
@@ -42,7 +42,7 @@ export class AsyncPoll extends EventEmitter {
                 await callback();
             } catch (err) {
                 logger.error(`Error Executing AsyncPoll ${err}`);
-                logger.error(`Stack trace for error: ${err.stack}`);
+                logger.debug(`Stack trace for error: ${err.stack}`);
             }
             if (!once) {
                 self.start();

--- a/src/__tests__/eventSubscriptionPosts.ts
+++ b/src/__tests__/eventSubscriptionPosts.ts
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 
 require('./testLoggingConfig');
 
@@ -6,30 +22,94 @@ const nock = require('nock');
 import { EventSubscriberAttrs, EventSubscription } from "../entity/EventSubscription";
 
 export const EventSubscriptionPostsTests = async function() {
-    let TEST_URL = 'http://TESTING-URL:9999';
-    let TEST_URL_PATH = '/testEvent';
-    let EVENTS = [{"blockNumber": 1}, {"blockNumber": 2}];
+    const TEST_URL = 'http://invalid.domain.shipchain.io';
+    const TEST_URL_PATH = '/testEvent';
+    const EVENTS = [{"blockNumber": 1}, {"blockNumber": 2}];
 
-    it(`Test event subscription response`, async () => {
-        nock(TEST_URL)
-            .post(TEST_URL_PATH)
-            .reply(204)
-            .post(TEST_URL_PATH)
-            .reply(400);
+    it(`Tracks highestChunkBlock with failure before any chunks are done`, async() => {
+        process.env.EVENT_CHUNK_SIZE = "1";
+
+        const thisNock = nock(TEST_URL)
+            .post(TEST_URL_PATH).reply(400, "Error");
 
         const subscriberAttrs = new EventSubscriberAttrs();
         subscriberAttrs.project = 'LOAD';
         subscriberAttrs.url = TEST_URL + TEST_URL_PATH;
         subscriberAttrs.receiverType = 'POST';
+        subscriberAttrs.lastBlock = 0;
 
         const subscriber = await EventSubscription.getOrCreate(subscriberAttrs);
-        subscriber.lastBlock = 0;
 
-        // @ts-ignore
-        await new Promise (async resolve => { await EventSubscription.sendPostEvents(subscriber, EVENTS, 0, resolve); });
+        let posted = new Promise (async (resolve, reject) => {
+            //@ts-ignore
+            await EventSubscription.sendPostEvents(subscriber, EVENTS, resolve);
+        });
 
-        expect(subscriber.lastBlock).toEqual(1);
+        await posted;
 
+        expect(+subscriber.lastBlock).toEqual(0);
+
+        await EventSubscription.unsubscribe(subscriberAttrs.url, subscriberAttrs.project);
+
+        expect(thisNock.isDone()).toBeTruthy();
+    });
+
+    it(`Tracks highestChunkBlock with failure before all chunks are done`, async() => {
+        process.env.EVENT_CHUNK_SIZE = "1";
+
+        const thisNock = nock(TEST_URL)
+            .post(TEST_URL_PATH).reply(204)
+            .post(TEST_URL_PATH).reply(400, "Error");
+
+        const subscriberAttrs = new EventSubscriberAttrs();
+        subscriberAttrs.project = 'LOAD';
+        subscriberAttrs.url = TEST_URL + TEST_URL_PATH;
+        subscriberAttrs.receiverType = 'POST';
+        subscriberAttrs.lastBlock = 0;
+
+        const subscriber = await EventSubscription.getOrCreate(subscriberAttrs);
+
+        let posted = new Promise (async (resolve, reject) => {
+            //@ts-ignore
+            await EventSubscription.sendPostEvents(subscriber, EVENTS, resolve);
+        });
+
+        await posted;
+
+        expect(+subscriber.lastBlock).toEqual(1);
+
+        await EventSubscription.unsubscribe(subscriberAttrs.url, subscriberAttrs.project);
+
+        expect(thisNock.isDone()).toBeTruthy();
+    });
+
+    it(`Tracks highestChunkBlock when all chunks are successful`,  async() => {
+        process.env.EVENT_CHUNK_SIZE = "1";
+
+        const thisNock = nock(TEST_URL)
+            .post(TEST_URL_PATH).reply(204)
+            .post(TEST_URL_PATH).reply(204);
+
+        const subscriberAttrs = new EventSubscriberAttrs();
+        subscriberAttrs.project = 'LOAD';
+        subscriberAttrs.url = TEST_URL + TEST_URL_PATH;
+        subscriberAttrs.receiverType = 'POST';
+        subscriberAttrs.lastBlock = 0;
+
+        const subscriber = await EventSubscription.getOrCreate(subscriberAttrs);
+
+        let posted = new Promise (async (resolve, reject) => {
+            //@ts-ignore
+            await EventSubscription.sendPostEvents(subscriber, EVENTS, resolve);
+        });
+
+        await posted;
+
+        expect(+subscriber.lastBlock).toEqual(2);
+
+        await EventSubscription.unsubscribe(subscriberAttrs.url, subscriberAttrs.project);
+
+        expect(thisNock.isDone()).toBeTruthy();
     });
 
 };

--- a/src/__tests__/eventSubscriptionPosts.ts
+++ b/src/__tests__/eventSubscriptionPosts.ts
@@ -1,0 +1,35 @@
+
+require('./testLoggingConfig');
+
+import 'mocha';
+const nock = require('nock');
+import { EventSubscriberAttrs, EventSubscription } from "../entity/EventSubscription";
+
+export const EventSubscriptionPostsTests = async function() {
+    let TEST_URL = 'http://TESTING-URL:9999';
+    let TEST_URL_PATH = '/testEvent';
+    let EVENTS = [{"blockNumber": 1}, {"blockNumber": 2}];
+
+    it(`Test event subscription response`, async () => {
+        nock(TEST_URL)
+            .post(TEST_URL_PATH)
+            .reply(204)
+            .post(TEST_URL_PATH)
+            .reply(400);
+
+        const subscriberAttrs = new EventSubscriberAttrs();
+        subscriberAttrs.project = 'LOAD';
+        subscriberAttrs.url = TEST_URL + TEST_URL_PATH;
+        subscriberAttrs.receiverType = 'POST';
+
+        const subscriber = await EventSubscription.getOrCreate(subscriberAttrs);
+        subscriber.lastBlock = 0;
+
+        // @ts-ignore
+        await new Promise (async resolve => { await EventSubscription.sendPostEvents(subscriber, EVENTS, 0, resolve); });
+
+        expect(subscriber.lastBlock).toEqual(1);
+
+    });
+
+};

--- a/src/__tests__/gaspriceoracle.ts
+++ b/src/__tests__/gaspriceoracle.ts
@@ -17,7 +17,7 @@
 require('./testLoggingConfig');
 
 import 'mocha';
-const nock = require('nock')
+const nock = require('nock');
 import { GasPriceOracle } from '../GasPriceOracle';
 
 export const GasPriceOracleTests = async function() {

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require('./testLoggingConfig');
+
+import 'mocha';
+import { arrayChunker } from "../utils";
+
+export const UtilsTests = async function() {
+
+    it(`arrayChunker works as expected`, async() => {
+        const array15 = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15];
+
+        const chunk2 = arrayChunker(array15, 2);
+        expect(chunk2).toEqual([[1, 2], [3, 4], [5, 6], [7, 8], [9, 10], [11, 12], [13, 14], [15]]);
+
+        const chunk3 = arrayChunker(array15, 3);
+        expect(chunk3).toEqual([[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12], [13, 14, 15]]);
+
+        const chunk16 = arrayChunker(array15, 16);
+        expect(chunk16).toEqual([[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]]);
+    });
+
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,13 +89,8 @@ export function delay(ms: number): Promise<void> {
 
 export function arrayChunker(array, size) {
     const chunked_arr = [];
-    for (let i = 0; i < array.length; i++) {
-        const last = chunked_arr[chunked_arr.length - 1];
-        if (!last || last.length === size) {
-            chunked_arr.push([array[i]]);
-        } else {
-            last.push(array[i]);
-        }
+    for (let index = 0; index < array.length; index += size) {
+        chunked_arr.push(array.slice(index, size + index));
     }
     return chunked_arr;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,3 +86,16 @@ export function verifyHash(obj) {
 export function delay(ms: number): Promise<void> {
     return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+export function arrayChunker(array, size) {
+    const chunked_arr = [];
+    for (let i = 0; i < array.length; i++) {
+        const last = chunked_arr[chunked_arr.length - 1];
+        if (!last || last.length === size) {
+            chunked_arr.push([array[i]]);
+        } else {
+            last.push(array[i]);
+        }
+    }
+    return chunked_arr;
+}


### PR DESCRIPTION
Before, Engine would send the event calls to Transmission in a larger group. If there were a very large amount of events, this could cause issues. This push batches the events into smaller, configurable amount before making the calls to Transmission.