### PR TITLE
Include project title in event call

### DIFF
--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -281,16 +281,13 @@ export class EventSubscription extends BaseEntity {
                 let options = {
                     url: eventSubscription.url + '/events/_doc',
                     json: {
-                        events: {
-                            network_id: eventSubscription.contract.network.id,
-                            network_title: eventSubscription.contract.network.title,
-                            project_id: eventSubscription.contract.project.id,
-                            project_title: eventSubscription.contract.project.title,
-                            version_id: eventSubscription.contract.version.id,
-                            version_title: eventSubscription.contract.version.title,
-                            ...event,
-                        },
-                        project: eventSubscription.project,
+                        network_id: eventSubscription.contract.network.id,
+                        network_title: eventSubscription.contract.network.title,
+                        project_id: eventSubscription.contract.project.id,
+                        project_title: eventSubscription.contract.project.title,
+                        version_id: eventSubscription.contract.version.id,
+                        version_title: eventSubscription.contract.version.title,
+                        ...event,
                     },
                     timeout: 1 * SECONDS,
                 };

--- a/src/entity/EventSubscription.ts
+++ b/src/entity/EventSubscription.ts
@@ -253,7 +253,10 @@ export class EventSubscription extends BaseEntity {
     private static async sendPostEventsChunk(eventSubscription: EventSubscription, chunk, highestChunkBlock) {
         let options = {
             url: eventSubscription.url,
-            json: chunk,
+            json: {
+                events: chunk,
+                project: eventSubscription.project,
+            },
             timeout: 90 * SECONDS,
         };
 
@@ -278,13 +281,16 @@ export class EventSubscription extends BaseEntity {
                 let options = {
                     url: eventSubscription.url + '/events/_doc',
                     json: {
-                        network_id: eventSubscription.contract.network.id,
-                        network_title: eventSubscription.contract.network.title,
-                        project_id: eventSubscription.contract.project.id,
-                        project_title: eventSubscription.contract.project.title,
-                        version_id: eventSubscription.contract.version.id,
-                        version_title: eventSubscription.contract.version.title,
-                        ...event,
+                        events: {
+                            network_id: eventSubscription.contract.network.id,
+                            network_title: eventSubscription.contract.network.title,
+                            project_id: eventSubscription.contract.project.id,
+                            project_title: eventSubscription.contract.project.title,
+                            version_id: eventSubscription.contract.version.id,
+                            version_title: eventSubscription.contract.version.title,
+                            ...event,
+                        },
+                        project: eventSubscription.project,
                     },
                     timeout: 1 * SECONDS,
                 };


### PR DESCRIPTION
When sending event information, the project name is not included. This change fixes that, but since it changes the event response then it needs to be paired with a change in Transmission.