### PR TITLE
Feature vault compression

### DIFF
--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -119,7 +119,7 @@ export const RPCVaultTests = async function() {
         vaultToMigrate.roles.ledger["public_key"] = role.publicKey;
         vaultToMigrate.roles.ledger[fullWallet1.public_key] = key2;
         signedVaultToMigrate = JSON.stringify(signObject(fullWallet1, vaultToMigrate));
-        await fs.writeFile(`./${dummyId}/meta.json`, signedVaultToMigrate);
+        fs.writeFileSync(`./${dummyId}/meta.json`, signedVaultToMigrate);
 
         await buildSchemaValidators();
 

--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -23,6 +23,7 @@ const fs = require('fs');
 
 import 'mocha';
 import * as typeorm from "typeorm";
+import * as path from 'path';
 const AWS = require('aws-sdk');
 import {
     mochaAsync,
@@ -90,6 +91,7 @@ export const RPCVaultTests = async function() {
 
     let testableLocalVaultId;
     let emptyLocalVaultId;
+    let vaultDir;
     let signedVaultToMigrate;
 
     let knownShipmentSchemaId = uuidv4();
@@ -119,7 +121,9 @@ export const RPCVaultTests = async function() {
         vaultToMigrate.roles.ledger["public_key"] = role.publicKey;
         vaultToMigrate.roles.ledger[fullWallet1.public_key] = key2;
         signedVaultToMigrate = JSON.stringify(signObject(fullWallet1, vaultToMigrate));
-        fs.writeFileSync(`./${dummyId}/meta.json`, signedVaultToMigrate);
+        vaultDir = `/app/${dummyId}/`;
+        fs.mkdirSync(vaultDir, {recursive: true});
+        fs.writeFileSync(`${vaultDir}/meta.json`, signedVaultToMigrate);
 
         await buildSchemaValidators();
 
@@ -2205,9 +2209,9 @@ export const RPCVaultTests = async function() {
                 });
                 expect(result.success).toBeTruthy();
                 expect(result.vault_signed).toBeDefined();
-                expect(fs.existsSync(`./${dummyId}/tracking/20180101.json`)).toBeTruthy();
-                expect(fs.existsSync(`./${dummyId}/meta.json`)).toBeTruthy();
-                const meta = JSON.parse(fs.readFileSync(`./${dummyId}/meta.json`));
+                expect(fs.existsSync(`${vaultDir}/tracking/20180101.json`)).toBeTruthy();
+                expect(fs.existsSync(`${vaultDir}/meta.json`)).toBeTruthy();
+                const meta = JSON.parse(fs.readFileSync(`${vaultDir}/meta.json`));
                 expect(meta.version == newVersion).toBeTruthy();
                 expect(typeof meta.containers.tracking == "string").toBeTruthy();
                 expect(typeof meta.containers.ledger == "string").toBeTruthy();

--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -35,7 +35,7 @@ import {
 
 import { buildSchemaValidators } from "../validators";
 import { RPCVault } from '../vault';
-import { uuidv4 } from "../../src/utils";
+import { uuidv4, signObject } from "../../src/utils";
 import { StorageCredential } from "../../src/entity/StorageCredential";
 import { Wallet } from "../../src/entity/Wallet";
 import { EncryptorContainer } from '../../src/entity/encryption/EncryptorContainer';
@@ -45,6 +45,24 @@ const DATE_1 = '2018-01-01T01:00:00.000Z';
 const DATE_2 = '2018-01-01T02:00:00.000Z';
 const DATE_3 = '2018-01-01T03:00:00.000Z';
 const DATE_4 = '2018-01-01T04:00:00.000Z';
+const dummyId = 'e7721042-7ee1-4d92-93db-c9544b454abf';
+const oldVersion = '0.0.1';
+const newVersion = '0.0.2';
+let vaultToMigrate = {
+    containers: {
+        tracking: {
+            container_type: "external_list_daily",
+            roles: ["owners"]
+        }
+    },
+    roles: {
+        owners: { public_key: "" },
+        ledger: { public_key: ""}
+    },
+    created: DATE_1,
+    id: dummyId,
+    version: oldVersion
+};
 
 export const RPCVaultTests = async function() {
     const RealDate = Date;
@@ -72,6 +90,7 @@ export const RPCVaultTests = async function() {
 
     let testableLocalVaultId;
     let emptyLocalVaultId;
+    let signedVaultToMigrate;
 
     let knownShipmentSchemaId = uuidv4();
     let knownDocumentContentb64 = 'iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mN8U+T4nYEIwDiqkL4KAZKnGefMCAbPAAAAAElFTkSuQmCC';
@@ -91,6 +110,16 @@ export const RPCVaultTests = async function() {
             driver_type: 'local',
         });
         await localStorage.save();
+
+        const role = Wallet.generate_identity();
+        const key1 = await Wallet.encrypt_to_string(fullWallet1.public_key, role.privateKey);
+        const key2 = await Wallet.encrypt_to_string(fullWallet1.public_key, role.privateKey);
+        vaultToMigrate.roles.owners["public_key"] = role.publicKey;
+        vaultToMigrate.roles.owners[fullWallet1.public_key] = key1;
+        vaultToMigrate.roles.ledger["public_key"] = role.publicKey;
+        vaultToMigrate.roles.ledger[fullWallet1.public_key] = key2;
+        signedVaultToMigrate = JSON.stringify(signObject(fullWallet1, vaultToMigrate));
+        await fs.writeFile(`./${dummyId}/meta.json`, signedVaultToMigrate);
 
         await buildSchemaValidators();
 
@@ -2161,6 +2190,32 @@ export const RPCVaultTests = async function() {
                 expect(err.message).toEqual(`No data found for date`);
             }
         }));
+    });
+
+    describe('migrateVault', function() {
+        it(`Migrate an old vault upon modification request`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.AddTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: dummyId,
+                    payload: {
+                        some: 'data'
+                    },
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.vault_signed).toBeDefined();
+                expect(fs.existsSync(`./${dummyId}/tracking/20180101.json`)).toBeTruthy();
+                expect(fs.existsSync(`./${dummyId}/meta.json`)).toBeTruthy();
+                const meta = JSON.parse(fs.readFileSync(`./${dummyId}/meta.json`));
+                expect(meta.version == newVersion).toBeTruthy();
+                expect(typeof meta.containers.tracking == "string").toBeTruthy();
+                expect(typeof meta.containers.ledger == "string").toBeTruthy();
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
     });
 
 };

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -312,16 +312,18 @@ export class Vault {
         }
     }
 
-    upgradeVault(upgrade: boolean = true) {
-        if (this.meta.version != Vault.CURRENT_VAULT_VERSION && upgrade) {
+    upgradeVault(upgrade: boolean) {
+        if (upgrade) {
             logger.debug(`Migrating vault ${this.id} to version ${Vault.CURRENT_VAULT_VERSION}`);
             this.meta.version = Vault.CURRENT_VAULT_VERSION;
+        } else {
+            return;
         }
     }
 
-    async writeMetadata(author: Wallet, upgrade: boolean = true) {
+    async writeMetadata(author: Wallet) {
         logger.info(`Writing Vault ${this.id} Metadata`);
-        this.upgradeVault(upgrade);
+        this.upgradeVault(this.meta.version != Vault.CURRENT_VAULT_VERSION);
         await this.updateContainerMetadata(author);
         this.meta = utils.signObject(author, this.meta);
         for (const name in this.meta.containers) {

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -280,22 +280,17 @@ export class Vault {
     }
 
     async loadMetadata() {
-        let contentJson, compressedContainerSize: number = 0, deCompressedContainerSize: number = 0;
+        let contentJson;
+        let compressedContainerSize: number = 0;
+        let deCompressedContainerSize: number = 0;
         try {
             const data = await this.getFile(Vault.METADATA_FILE_NAME);
             this.meta = await JSON.parse(data);
             this.containers = {};
             for (const name in this.meta.containers) {
-                console.log(`------------------------ Container: ${name}, data ---------------------------`);
                 compressedContainerSize = compressedContainerSize + this.meta.containers[name].length;
-                console.log(`Compressed container content length: ${this.meta.containers[name].length}`);
-                console.log(`Compressed container size: ${Buffer.byteLength(this.meta.containers[name], 'utf8')}`);
-
                 contentJson = await this.getContainerContent(this.meta.containers[name]);
-
                 deCompressedContainerSize = deCompressedContainerSize + JSON.stringify(contentJson).length;
-                console.log(`Decompressed container content length: ${JSON.stringify(contentJson).length}`);
-                console.log(`Decompressed container size: ${Buffer.byteLength(JSON.stringify(contentJson), 'utf8')}`);
 
                 this.containers[name] = Container.typeFactory(
                    contentJson.container_type,
@@ -304,11 +299,8 @@ export class Vault {
                    contentJson,
                 );
             }
-            console.log(`########### Total Compressed Containers size: ${compressedContainerSize} #################`);
-            console.log(`########### Total Decompressed Containers size: ${deCompressedContainerSize} ################`);
-            console.log(`>>>>>>>>>> Data rate saving: ${(1-compressedContainerSize/deCompressedContainerSize)*100}`);
 
-           // TODO: Check Vault Version number and apply migrations if necessary
+            logger.debug(`saving rate: ${(1-compressedContainerSize/deCompressedContainerSize)*100}`);
            return this.meta;
         } catch (_err) {
             if (_err instanceof DriverError) {

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -314,6 +314,7 @@ export class Vault {
 
     upgradeVault(upgrade: boolean = true) {
         if (this.meta.version != Vault.CURRENT_VAULT_VERSION && upgrade) {
+            logger.debug(`Migrating vault ${this.id} to version ${Vault.CURRENT_VAULT_VERSION}`);
             this.meta.version = Vault.CURRENT_VAULT_VERSION;
         }
     }


### PR DESCRIPTION
This PR modifies the vault structure allowing its compression to the end of gaining in I/O data transfer. In local tests, a data saving beyond `50%` has been observed.
Here are the main changes carried out:
- Refactor vault meta containers to be compressed values instead of objects.
- Update vault version
- Ensure that vault migration appends on a case basis and on next change request
- Add vault migration test case 