### PR TITLE
Vault Sequence Retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,13 +762,19 @@ Listing the files included in this container is performed via:
 
 An Engine Vault contains a running Ledger of all actions taken in each Container.  This data is encrypted with a special role and is viewable by users in that Ledger role only; by default the Shipper is included in this role.  This provides the ability to generate Vault data that was present at any previous date by replaying previous actions up to the specified date.
 
-Each of the above containers (shipment, tracking, documents) support this historical retrieval and getting this prior data is handled via new RPC methods.
+Each of the above containers (shipment, tracking, documents) support this historical retrieval and getting this prior data is handled via these RPC methods.
 
  - `get_historical_shipment_data`
  - `get_historical_tracking_data`
  - `get_historical_document`
 
-These are called the same as their non-historical counterparts, except they require an additional parameter `date`. This new parameter is the date (UTC) at which you wish to view the contents. If no contents existed before the date you specify, you will receive an error indicating this. The format of this new date field follows the ISO8601 standard `YYYY-MM-DDTHH:mm:ss.SSSZ`.
+These are called the same as their non-historical counterparts, except they require one of two additional parameters `date` or `sequence`. These new parameters specify a version of the vault to get the data from; either the date (UTC) or the vault sequence at which you wish to view the contents.
+
+##### Date
+
+Specifying a Date will perform a type of "fuzzy" retrieval.  If no contents existed before the date you specify, you will receive an error indicating this. 
+However, if data has existed prior to the date you specify, then you will get the value of the data _that would have existed_ at the time, even if there 
+was no specific data storage action at that timestamp.  The format of this new date field follows the ISO8601 standard `YYYY-MM-DDTHH:mm:ss.SSSZ`.
 
 For example, to retrieve the contents of the file `example.png` as it existed in the vault as of 2:00 pm UTC on November 1st, 2018 use the following request:
 
@@ -786,6 +792,12 @@ For example, to retrieve the contents of the file `example.png` as it existed in
   "id": 0
 }
 ```
+
+##### Sequence
+
+Specifying a sequence will perform an exact lookup in the ledger.  If no data for the specified container exists at the sequence you will receive an error 
+indicating this. The only exception to this is List based containers, these will still perform a scan through the ledger to rebuild the data up to the
+specified index.
 
 ### Load Contract
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ajv": "^6.6.1",
     "app-root-path": "^2.1.0",
     "aws-sdk": "^2.366.0",
+    "compare-versions": "^3.5.0",
     "config": "^3.1.0",
     "eth-crypto": "^1.3.4",
     "ethereumjs-tx": "^1.3.7",

--- a/rpc/Engine.postman_collection.json
+++ b/rpc/Engine.postman_collection.json
@@ -1,13 +1,12 @@
 {
 	"info": {
-		"_postman_id": "72a5b104-82ad-409a-9187-9934ec2d92a4",
+		"_postman_id": "78855f56-57b2-44a4-8e0e-dabb744fc9de",
 		"name": "Engine",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
 			"name": "wallet",
-			"description": null,
 			"item": [
 				{
 					"name": "wallet.create_hosted",
@@ -125,7 +124,6 @@
 		},
 		{
 			"name": "event",
-			"description": null,
 			"item": [
 				{
 					"name": "event.subscribe",
@@ -187,7 +185,6 @@
 		},
 		{
 			"name": "storage_credentials",
-			"description": null,
 			"item": [
 				{
 					"name": "storage_credentials.create_hosted (S3)",
@@ -445,7 +442,6 @@
 		},
 		{
 			"name": "transaction",
-			"description": null,
 			"item": [
 				{
 					"name": "transaction.sign",
@@ -521,7 +517,6 @@
 		},
 		{
 			"name": "vault",
-			"description": null,
 			"item": [
 				{
 					"name": "vault.create_vault",
@@ -832,7 +827,7 @@
 					"response": []
 				},
 				{
-					"name": "vault.get_historical_document",
+					"name": "vault.get_historical_document [date]",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -860,7 +855,35 @@
 					"response": []
 				},
 				{
-					"name": "vault.get_historical_tracking_data",
+					"name": "vault.get_historical_document  [sequence]",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"vault.get_historical_document\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"sequence\": 2,\n\t\t\"documentName\": \"example.png\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "http://localhost:2000/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "2000",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "vault.get_historical_tracking_data [date]",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -888,7 +911,35 @@
 					"response": []
 				},
 				{
-					"name": "vault.get_historical_shipment_data",
+					"name": "vault.get_historical_tracking_data  [sequence]",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"vault.get_historical_tracking_data\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"sequence\": 2\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "http://localhost:2000/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "2000",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "vault.get_historical_shipment_data [date]",
 					"request": {
 						"method": "POST",
 						"header": [
@@ -914,20 +965,45 @@
 						}
 					},
 					"response": []
+				},
+				{
+					"name": "vault.get_historical_shipment_data [sequence]",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"vault.get_historical_shipment_data\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"a350758d-2dd8-4bab-b983-2390657bbc25\",\n\t\t\"vaultWallet\": \"a245bf61-6669-4d5a-b305-e8a6c39993e7\",\n\t\t\"vault\": \"2ed96ba9-26d4-4f26-b3da-c45562268480\",\n\t\t\"sequence\": 2\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "http://localhost:2000/",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "2000",
+							"path": [
+								""
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		},
 		{
 			"name": "load",
-			"description": null,
 			"item": [
 				{
 					"name": "load.1.0.2",
-					"description": null,
 					"item": [
 						{
 							"name": "tx",
-							"description": "These requests generate a transaction that needs to be signed and submitted via `transaction.sign` and `transaction.send`, respetively.\n\nGenerated transaction is stored in a Postman environment variable `tx_unsigned` by the \"Test\" script defined here.",
 							"item": [
 								{
 									"name": "load.1.0.2.create_shipment_transaction",
@@ -1330,6 +1406,7 @@
 									"response": []
 								}
 							],
+							"description": "These requests generate a transaction that needs to be signed and submitted via `transaction.sign` and `transaction.send`, respetively.\n\nGenerated transaction is stored in a Postman environment variable `tx_unsigned` by the \"Test\" script defined here.",
 							"event": [
 								{
 									"listen": "prerequest",
@@ -1358,7 +1435,6 @@
 						},
 						{
 							"name": "status",
-							"description": null,
 							"item": [
 								{
 									"name": "load.1.0.2.get_shipment_details",
@@ -1492,11 +1568,9 @@
 				},
 				{
 					"name": "load.1.1.0",
-					"description": null,
 					"item": [
 						{
 							"name": "tx",
-							"description": null,
 							"item": [
 								{
 									"name": "load.1.1.0.create_shipment_tx",
@@ -2087,7 +2161,6 @@
 						},
 						{
 							"name": "status",
-							"description": null,
 							"item": [
 								{
 									"name": "load.1.1.0.get_shipment_data",

--- a/rpc/__tests__/utils.ts
+++ b/rpc/__tests__/utils.ts
@@ -105,6 +105,35 @@ export const expectInvalidDateParams = (throwable: Error, params: string[]) => {
     expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
 };
 
+// RPCMethod decorator throws this error when provided argument does not match expected format
+export const expectInvalidNumberParams = (throwable: Error, params: string[]) => {
+    if(!throwable){
+        fail("No Error when one was expected!");
+        return;
+    }
+    const missingPrefix = `Invalid Number${params.length === 1 ? '' : 's'}`;
+    expect(throwable.message).toMatch(`${missingPrefix}: '${params.join(', ')}'`);
+};
+
+// RPCMethod decorator throws this error when provided argument does not match expected format
+export const expectInvalidParameterCombinationParams = (throwable: Error, options: string[][], provided: string[][]) => {
+    if(!throwable){
+        fail("No Error when one was expected!");
+        return;
+    }
+    const missingPrefix = `Invalid Parameter Combination${options.length === 1 ? '' : 's'}`;
+    let paramStrings = [];
+    for (let [index, option] of options.entries()) {
+        if (provided[index].length === 0) {
+            paramStrings.push(`One of the following must be provided [${option.join(', ')}]`);
+        }
+        if (provided[index].length === 2) {
+            paramStrings.push(`Only one of the following can be provided [${option.join(', ')}]`);
+        }
+    }
+    expect(throwable.message).toMatch(`${missingPrefix}: '${paramStrings.join(', ')}'`);
+};
+
 // RPCMethod decorated methods are called in the RPC Server context which handles
 // returning data and/or errors via callbacks.  Since we're calling these directly
 // we need a utility method to act as that callback to resolve/reject from the method

--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -1836,6 +1836,63 @@ export const RPCVaultTests = async function() {
                 fail(`Should not have thrown [${err}]`);
             }
         }));
+
+        it(`Throws when sequence is not for container`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Ledger data at index 1 is not for container shipment`);
+            }
+        }));
+
+        it(`Returns intermediate data at a sequence for shipment data`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 2,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    shipment: {
+                        id: knownShipmentSchemaId,
+                        version: '0.0.1',
+                    },
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Returns other data at a sequence for shipment data`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 6,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    shipment: {
+                        id: knownShipmentSchemaId,
+                        version: '0.0.2',
+                    },
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
     });
 
     describe('GetHistoricalTrackingData', function() {
@@ -2063,6 +2120,63 @@ export const RPCVaultTests = async function() {
                         some: 'data',
                     },{
                         more: 'data'
+                    }],
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Throws when no data exists for sequence`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 0,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`No data found at specific sequence`);
+            }
+        }));
+
+        it(`Returns Tracking data up to a sequence 2`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 3,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    tracking: [{
+                        'some': 'data',
+                    }],
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Returns Tracking data up to a sequence 3`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 8,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    tracking: [{
+                        'some': 'data',
+                    },{
+                        'more': 'data',
                     }],
                 });
             } catch (err) {
@@ -2356,6 +2470,59 @@ export const RPCVaultTests = async function() {
                 fail("Did not Throw"); return;
             } catch (err) {
                 expect(err.message).toEqual(`No data found for date`);
+            }
+        }));
+
+        it(`Throws when sequence is not for container`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 1,
+                    documentName: 'none.png',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`Ledger data at index 1 is not for container documents`);
+            }
+        }));
+
+        it(`Throws when no data for specific document exists for sequence`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 3,
+                    documentName: 'none.png',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toEqual(`No data found at specific sequence`);
+            }
+        }));
+
+        it(`Returns data at a sequence for specific document when exists`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 3,
+                    documentName: 'test.png',
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    documents: {
+                        'test.png': knownDocumentContent,
+                    },
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
             }
         }));
     });

--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -30,6 +30,8 @@ import {
     expectMissingRequiredParams,
     expectInvalidUUIDParams,
     expectInvalidDateParams,
+    expectInvalidNumberParams,
+    expectInvalidParameterCombinationParams,
     cleanupEntities,
     CallRPCMethod,
 } from "./utils";
@@ -1613,7 +1615,43 @@ export const RPCVaultTests = async function() {
                 caughtError = err;
             }
 
-            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'date']);
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Requires date or sequence`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidParameterCombinationParams(caughtError, [['date', 'sequence']], [[]]);
+        }));
+
+        it(`Requires only date or sequence`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_1,
+                    sequence: 1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidParameterCombinationParams(caughtError, [['date', 'sequence']], [['date', 'sequence']]);
         }));
 
         it(`Validates UUID parameters`, mochaAsync(async () => {
@@ -1650,6 +1688,24 @@ export const RPCVaultTests = async function() {
             }
 
             expectInvalidDateParams(caughtError, ['date']);
+        }));
+
+        it(`Validates Number parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalShipmentData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 'not a number',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidNumberParams(caughtError, ['sequence']);
         }));
 
         it(`Validates StorageCredentials exists`, mochaAsync(async () => {
@@ -1793,7 +1849,43 @@ export const RPCVaultTests = async function() {
                 caughtError = err;
             }
 
-            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'date']);
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Requires date or sequence`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidParameterCombinationParams(caughtError, [['date', 'sequence']], [[]]);
+        }));
+
+        it(`Requires only date or sequence`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_1,
+                    sequence: 1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidParameterCombinationParams(caughtError, [['date', 'sequence']], [['date', 'sequence']]);
         }));
 
         it(`Validates UUID parameters`, mochaAsync(async () => {
@@ -1830,6 +1922,24 @@ export const RPCVaultTests = async function() {
             }
 
             expectInvalidDateParams(caughtError, ['date']);
+        }));
+
+        it(`Validates Number parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTrackingData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 'not a number',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidNumberParams(caughtError, ['sequence']);
         }));
 
         it(`Validates StorageCredentials exists`, mochaAsync(async () => {
@@ -1972,7 +2082,43 @@ export const RPCVaultTests = async function() {
                 caughtError = err;
             }
 
-            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'date']);
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Requires date or sequence`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidParameterCombinationParams(caughtError, [['date', 'sequence']], [[]]);
+        }));
+
+        it(`Requires only date or sequence`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_1,
+                    sequence: 1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidParameterCombinationParams(caughtError, [['date', 'sequence']], [['date', 'sequence']]);
         }));
 
         it(`Validates UUID parameters`, mochaAsync(async () => {
@@ -2009,6 +2155,24 @@ export const RPCVaultTests = async function() {
             }
 
             expectInvalidDateParams(caughtError, ['date']);
+        }));
+
+        it(`Validates Number parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalDocument, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 'not a number',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidNumberParams(caughtError, ['sequence']);
         }));
 
         it(`Validates documentName is string if provided`, mochaAsync(async () => {

--- a/rpc/decorators.ts
+++ b/rpc/decorators.ts
@@ -66,19 +66,22 @@ class RPCMethodValidateRequireOne {
     arg1: string;
     arg2: string;
 
-    private __found__: number = 0;
+    private readonly __found__: number = 0;
 
-    constructor(arg1: string, arg2: string) {
+    constructor(arg1: string, arg2: string, providedArgs: any) {
         this.arg1 = arg1;
         this.arg2 = arg2;
+
+        if (providedArgs && providedArgs.hasOwnProperty(this.arg1)) {
+            this.__found__ += 1;
+        }
+        if (providedArgs && providedArgs.hasOwnProperty(this.arg2)) {
+            this.__found__ += 1;
+        }
     }
 
-    public static fromRPCMethodValidateRequireOneOptions(options: RPCMethodValidateRequireOneOptions) {
-        return new RPCMethodValidateRequireOne(options.arg1, options.arg2);
-    }
-
-    public foundOne() {
-        this.__found__ += 1;
+    public static fromOptions(options: RPCMethodValidateRequireOneOptions, args: any) {
+        return new RPCMethodValidateRequireOne(options.arg1, options.arg2, args);
     }
 
     public isValid() {
@@ -265,15 +268,10 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
     // -------------------
     if (validations && validations.requireOne) {
         for (let requireOneOptions of validations.requireOne) {
-            let requireOne: RPCMethodValidateRequireOne = RPCMethodValidateRequireOne.fromRPCMethodValidateRequireOneOptions(
+            let requireOne: RPCMethodValidateRequireOne = RPCMethodValidateRequireOne.fromOptions(
                 requireOneOptions,
+                args,
             );
-            if (args && args.hasOwnProperty(requireOne.arg1)) {
-                requireOne.foundOne();
-            }
-            if (args && args.hasOwnProperty(requireOne.arg2)) {
-                requireOne.foundOne();
-            }
             if (!requireOne.isValid()) {
                 failed.push(`${requireOne}`);
             }

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -341,10 +341,12 @@ export class RPCVault {
     }
 
     @RPCMethod({
-        require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
+        require: ['storageCredentials', 'vaultWallet', 'vault'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
             date: ['date'],
+            number: ['sequence'],
+            requireOne: [{ arg1: 'date', arg2: 'sequence' }],
         },
     })
     public static async GetHistoricalShipmentData(args) {
@@ -352,7 +354,13 @@ export class RPCVault {
         const wallet = await Wallet.getById(args.vaultWallet);
 
         const load = new LoadVault(storage, args.vault);
-        const contents = await load.getHistoricalShipment(wallet, args.date);
+        let contents;
+
+        if (args.date) {
+            contents = await load.getHistoricalShipmentByDate(wallet, args.date);
+        } else {
+            contents = await load.getHistoricalShipmentBySequence(wallet, args.sequence);
+        }
 
         return {
             success: true,
@@ -363,10 +371,12 @@ export class RPCVault {
     }
 
     @RPCMethod({
-        require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
+        require: ['storageCredentials', 'vaultWallet', 'vault'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
             date: ['date'],
+            number: ['sequence'],
+            requireOne: [{ arg1: 'date', arg2: 'sequence' }],
         },
     })
     public static async GetHistoricalTrackingData(args) {
@@ -374,7 +384,13 @@ export class RPCVault {
         const wallet = await Wallet.getById(args.vaultWallet);
 
         const load = new LoadVault(storage, args.vault);
-        const contents = await load.getHistoricalTracking(wallet, args.date);
+        let contents;
+
+        if (args.date) {
+            contents = await load.getHistoricalTrackingByDate(wallet, args.date);
+        } else {
+            contents = await load.getHistoricalTrackingBySequence(wallet, args.sequence);
+        }
 
         return {
             success: true,
@@ -385,11 +401,13 @@ export class RPCVault {
     }
 
     @RPCMethod({
-        require: ['storageCredentials', 'vaultWallet', 'vault', 'date'],
+        require: ['storageCredentials', 'vaultWallet', 'vault'],
         validate: {
             uuid: ['storageCredentials', 'vaultWallet', 'vault'],
             date: ['date'],
+            number: ['sequence'],
             string: ['documentName'],
+            requireOne: [{ arg1: 'date', arg2: 'sequence' }],
         },
     })
     public static async GetHistoricalDocument(args) {
@@ -397,7 +415,13 @@ export class RPCVault {
         const wallet = await Wallet.getById(args.vaultWallet);
 
         const load = new LoadVault(storage, args.vault);
-        const contents = await load.getHistoricalDocument(wallet, args.date, args.documentName);
+        let contents;
+
+        if (args.date) {
+            contents = await load.getHistoricalDocumentByDate(wallet, args.date, args.documentName);
+        } else {
+            contents = await load.getHistoricalDocumentBySequence(wallet, args.sequence, args.documentName);
+        }
 
         return {
             success: true,

--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -607,14 +607,14 @@ export const VaultTests = async function() {
         expect(test_0).toEqual([{minute: 2}, {minute: 4}]);
 
         try {
-            let failure = await vault.getHistoricalData(author, CONTAINER, DATE_1);
+            let failure = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_1);
             fail(`Should not have historical data for ${DATE_1}: '${JSON.stringify(failure)}'`);
         } catch(err){}
 
-        let test_1 = await vault.getHistoricalData(author, CONTAINER, DATE_3);
+        let test_1 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_3);
         expect(test_1[CONTAINER]).toEqual([{minute: 2}]);
 
-        let test_2 = await vault.getHistoricalData(author, CONTAINER, DATE_5);
+        let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
     });
 
@@ -649,14 +649,14 @@ export const VaultTests = async function() {
         expect(test_0).toEqual([{minute: 2}, {minute: 4}]);
 
         try {
-            let failure = await vault.getHistoricalData(author, CONTAINER, DATE_1);
+            let failure = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_1);
             fail(`Should not have historical data for ${DATE_1}: '${JSON.stringify(failure)}'`);
         } catch(err){}
 
-        let test_1 = await vault.getHistoricalData(author, CONTAINER, DATE_3);
+        let test_1 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_3);
         expect(test_1[CONTAINER]).toEqual([{minute: 2}]);
 
-        let test_2 = await vault.getHistoricalData(author, CONTAINER, DATE_5);
+        let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
     });
 
@@ -691,14 +691,14 @@ export const VaultTests = async function() {
         expect(test_0).toEqual([{minute: 2}, {minute: 4}]);
 
         try {
-            let failure = await vault.getHistoricalData(author, CONTAINER, DATE_1);
+            let failure = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_1);
             fail(`Should not have historical data for ${DATE_1}: '${JSON.stringify(failure)}'`);
         } catch(err){}
 
-        let test_1 = await vault.getHistoricalData(author, CONTAINER, DATE_3);
+        let test_1 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_3);
         expect(test_1[CONTAINER]).toEqual([{minute: 2}]);
 
-        let test_2 = await vault.getHistoricalData(author, CONTAINER, DATE_5);
+        let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
     });
 
@@ -731,14 +731,14 @@ export const VaultTests = async function() {
         expect(test_0).toEqual("4");
 
         try {
-            let failure = await vault.getHistoricalData(author, CONTAINER, DATE_1);
+            let failure = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_1);
             fail(`Should not have historical data for ${DATE_1}: '${JSON.stringify(failure)}'`);
         } catch(err){}
 
-        let test_1 = await vault.getHistoricalData(author, CONTAINER, DATE_3);
+        let test_1 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_3);
         expect(test_1[CONTAINER]).toEqual("2");
 
-        let test_2 = await vault.getHistoricalData(author, CONTAINER, DATE_5);
+        let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual("4");
     });
 
@@ -771,14 +771,14 @@ export const VaultTests = async function() {
         expect(test_0).toEqual("4");
 
         try {
-            let failure = await vault.getHistoricalData(author, CONTAINER, DATE_1);
+            let failure = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_1);
             fail(`Should not have historical data for ${DATE_1}: '${JSON.stringify(failure)}'`);
         } catch(err){}
 
-        let test_1 = await vault.getHistoricalData(author, CONTAINER, DATE_3);
+        let test_1 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_3);
         expect(test_1[CONTAINER]).toEqual("2");
 
-        let test_2 = await vault.getHistoricalData(author, CONTAINER, DATE_5);
+        let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual("4");
     });
 
@@ -816,25 +816,25 @@ export const VaultTests = async function() {
         expect(test_0).toEqual("2-4");
 
         try {
-            let failure = await vault.getHistoricalData(author, CONTAINER, DATE_1, FILE_1);
+            let failure = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_1, FILE_1);
             fail(`Should not have historical data for ${DATE_1} ${FILE_1}: '${JSON.stringify(failure)}'`);
         } catch(err){}
 
         try {
-            let failure = await vault.getHistoricalData(author, CONTAINER, DATE_1, FILE_2);
+            let failure = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_1, FILE_2);
             fail(`Should not have historical data for ${DATE_1} ${FILE_2}: '${JSON.stringify(failure)}'`);
         } catch(err){}
 
-        let test_1 = await vault.getHistoricalData(author, CONTAINER, DATE_3, FILE_1);
+        let test_1 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_3, FILE_1);
         expect(test_1[CONTAINER][FILE_1]).toEqual("1-2");
 
-        let test_2 = await vault.getHistoricalData(author, CONTAINER, DATE_3, FILE_2);
+        let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_3, FILE_2);
         expect(test_2[CONTAINER][FILE_2]).toEqual("2-2");
 
-        let test_3 = await vault.getHistoricalData(author, CONTAINER, DATE_5, FILE_1);
+        let test_3 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5, FILE_1);
         expect(test_3[CONTAINER][FILE_1]).toEqual("1-4");
 
-        let test_4 = await vault.getHistoricalData(author, CONTAINER, DATE_5, FILE_2);
+        let test_4 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5, FILE_2);
         expect(test_4[CONTAINER][FILE_2]).toEqual("2-4");
     });
 

--- a/src/__tests__/vaults.ts
+++ b/src/__tests__/vaults.ts
@@ -616,6 +616,12 @@ export const VaultTests = async function() {
 
         let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
+
+        let test_3 = await vault.getHistoricalDataBySequence(author, CONTAINER, 1);
+        expect(test_3[CONTAINER]).toEqual([{minute: 2}]);
+
+        let test_4 = await vault.getHistoricalDataBySequence(author, CONTAINER, 2);
+        expect(test_4[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
     });
 
     it(`can view historical External List content`, async () => {
@@ -658,6 +664,12 @@ export const VaultTests = async function() {
 
         let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
+
+        let test_3 = await vault.getHistoricalDataBySequence(author, CONTAINER, 1);
+        expect(test_3[CONTAINER]).toEqual([{minute: 2}]);
+
+        let test_4 = await vault.getHistoricalDataBySequence(author, CONTAINER, 2);
+        expect(test_4[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
     });
 
     it(`can view historical External List Daily content`, async () => {
@@ -700,6 +712,12 @@ export const VaultTests = async function() {
 
         let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
+
+        let test_3 = await vault.getHistoricalDataBySequence(author, CONTAINER, 1);
+        expect(test_3[CONTAINER]).toEqual([{minute: 2}]);
+
+        let test_4 = await vault.getHistoricalDataBySequence(author, CONTAINER, 2);
+        expect(test_4[CONTAINER]).toEqual([{minute: 2}, {minute: 4}]);
     });
 
     it(`can view historical Embedded File content`, async () => {
@@ -740,6 +758,12 @@ export const VaultTests = async function() {
 
         let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual("4");
+
+        let test_3 = await vault.getHistoricalDataBySequence(author, CONTAINER, 1);
+        expect(test_3[CONTAINER]).toEqual("2");
+
+        let test_4 = await vault.getHistoricalDataBySequence(author, CONTAINER, 2);
+        expect(test_4[CONTAINER]).toEqual("4");
     });
 
     it(`can view historical External File content`, async () => {
@@ -780,6 +804,12 @@ export const VaultTests = async function() {
 
         let test_2 = await vault.getHistoricalDataByDate(author, CONTAINER, DATE_5);
         expect(test_2[CONTAINER]).toEqual("4");
+
+        let test_3 = await vault.getHistoricalDataBySequence(author, CONTAINER, 1);
+        expect(test_3[CONTAINER]).toEqual("2");
+
+        let test_4 = await vault.getHistoricalDataBySequence(author, CONTAINER, 2);
+        expect(test_4[CONTAINER]).toEqual("4");
     });
 
     it(`can view historical External File Multi content`, async () => {

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -72,18 +72,18 @@ export class LoadVault extends Vault {
 
     async getHistoricalShipment(author: Wallet, date: string) {
         await this.loadMetadata();
-        const contents = await this.getHistoricalData(author, LoadVault.SHIPMENT, date);
+        const contents = await this.getHistoricalDataByDate(author, LoadVault.SHIPMENT, date);
         contents.shipment = JSON.parse(contents.shipment);
         return contents;
     }
 
     async getHistoricalTracking(author: Wallet, date: string) {
         await this.loadMetadata();
-        return await this.getHistoricalData(author, LoadVault.TRACKING, date);
+        return await this.getHistoricalDataByDate(author, LoadVault.TRACKING, date);
     }
 
     async getHistoricalDocument(author: Wallet, date: string, documentName: string) {
         await this.loadMetadata();
-        return await this.getHistoricalData(author, LoadVault.DOCUMENTS, date, documentName);
+        return await this.getHistoricalDataByDate(author, LoadVault.DOCUMENTS, date, documentName);
     }
 }

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -70,20 +70,40 @@ export class LoadVault extends Vault {
         return await this.containers[LoadVault.DOCUMENTS].listFiles();
     }
 
-    async getHistoricalShipment(author: Wallet, date: string) {
+    // Historical Retrievals
+    // =====================
+
+    async getHistoricalShipmentByDate(author: Wallet, date: string) {
         await this.loadMetadata();
         const contents = await this.getHistoricalDataByDate(author, LoadVault.SHIPMENT, date);
         contents.shipment = JSON.parse(contents.shipment);
         return contents;
     }
 
-    async getHistoricalTracking(author: Wallet, date: string) {
+    async getHistoricalTrackingByDate(author: Wallet, date: string) {
         await this.loadMetadata();
         return await this.getHistoricalDataByDate(author, LoadVault.TRACKING, date);
     }
 
-    async getHistoricalDocument(author: Wallet, date: string, documentName: string) {
+    async getHistoricalDocumentByDate(author: Wallet, date: string, documentName: string) {
         await this.loadMetadata();
         return await this.getHistoricalDataByDate(author, LoadVault.DOCUMENTS, date, documentName);
+    }
+
+    async getHistoricalShipmentBySequence(author: Wallet, sequence: number) {
+        await this.loadMetadata();
+        const contents = await this.getHistoricalDataBySequence(author, LoadVault.SHIPMENT, sequence);
+        contents.shipment = JSON.parse(contents.shipment);
+        return contents;
+    }
+
+    async getHistoricalTrackingBySequence(author: Wallet, sequence: number) {
+        await this.loadMetadata();
+        return await this.getHistoricalDataBySequence(author, LoadVault.TRACKING, sequence);
+    }
+
+    async getHistoricalDocumentBySequence(author: Wallet, sequence: number, documentName: string) {
+        await this.loadMetadata();
+        return await this.getHistoricalDataBySequence(author, LoadVault.DOCUMENTS, sequence, documentName);
     }
 }

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -972,11 +972,58 @@ export class ExternalFileMultiContainer extends ExternalDirectoryContainer imple
     }
 }
 
+class LedgerEntry {
+    public type: string;
+    public action: string;
+    public name: string;
+
+    constructor(type: string, action: string, name: string) {
+        this.type = type;
+        this.action = action;
+        this.name = name;
+    }
+
+    public static fromIndexData(indexData: any): LedgerEntry {
+        const action = indexData.action.split('.');
+        const containerType = action[1];
+        const containerAction = action[2];
+        return new LedgerEntry(containerType, containerAction, indexData.name);
+    }
+
+    public isFileContainer(): Boolean {
+        return this.type.indexOf('_file') != -1;
+    }
+
+    public isListContainer(): Boolean {
+        return this.type.indexOf('_list') != -1;
+    }
+
+    public isMultiFileContainer(): Boolean {
+        return this.isFileContainer() && this.type.indexOf('_multi') != -1;
+    }
+
+    public isSingleFileContainer(): Boolean {
+        return this.isFileContainer() && this.type.indexOf('_multi') == -1;
+    }
+
+    public isMultiFileSetContentAction(): Boolean {
+        return this.isMultiFileContainer() && this.action.indexOf('setsinglecontent') != -1;
+    }
+
+    public isSingleFileSetContentAction(): Boolean {
+        return this.isSingleFileContainer() && this.action.indexOf('setcontents') != -1;
+    }
+
+    public isListAppendAction(): Boolean {
+        return this.isListContainer() && this.action.indexOf('append') != -1;
+    }
+}
+
 export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
     public container_type: string = 'external_file_ledger';
     private nextIndex: number;
     private static readonly INDEX_PADDING: number = 7;
-    private static readonly MOMENT_FORMAT: string = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
+    public static readonly MOMENT_FORMAT: string = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
     constructor(vault: Vault, name: string, meta?: any) {
         super(vault, name, meta);
@@ -996,65 +1043,108 @@ export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
         this.nextIndex = this.nextIndex + 1;
     }
 
-    async decryptToIndex(user: Wallet, container: string = null, index: number = this.nextIndex - 1, subFile?: string) {
+    private static getFileContent(
+        ledgerEntry: LedgerEntry,
+        indexData: any,
+        decryptedContainers: any,
+        subFile?: string,
+    ) {
+        let foundApplicableData = false;
+
+        // Multi-file containers
+        if (ledgerEntry.isMultiFileSetContentAction()) {
+            if (!decryptedContainers[ledgerEntry.name]) {
+                decryptedContainers[ledgerEntry.name] = {};
+            }
+
+            if (subFile) {
+                if (subFile === indexData.params.fileName) {
+                    decryptedContainers[ledgerEntry.name][subFile] = indexData.params.blob;
+                    foundApplicableData = true;
+                }
+            } else {
+                decryptedContainers[ledgerEntry.name][indexData.params.fileName] = indexData.params.blob;
+                foundApplicableData = true;
+            }
+        }
+
+        // Single-file containers
+        else if (ledgerEntry.isSingleFileSetContentAction()) {
+            decryptedContainers[ledgerEntry.name] = indexData.params;
+            foundApplicableData = true;
+        }
+
+        return [foundApplicableData, decryptedContainers];
+    }
+
+    async decryptToIndex(
+        user: Wallet,
+        container: string = null,
+        index: number = this.nextIndex - 1,
+        subFile?: string,
+        approximateIndex: boolean = true,
+    ) {
         let foundApplicableData: boolean = false;
         let decryptedContainers = {};
+        let ledgerEntry: LedgerEntry = null;
 
-        for (let desiredIndex = 1; desiredIndex <= index && desiredIndex < this.nextIndex; desiredIndex++) {
-            let indexData = await this.decryptContents(user, this.paddedIndex(+desiredIndex));
+        // If container type is a file, then go straight to index
+        if (!approximateIndex && container && this.vault.containers[container].container_type.indexOf('_file') != -1) {
+            let indexData = await this.decryptContents(user, this.paddedIndex(+index));
             indexData = JSON.parse(indexData);
-            const containerName = indexData.name;
 
-            if (!container || containerName === container) {
-                const action = indexData.action.split('.');
-                const containerType = action[1];
-                const containerAction = action[2];
+            ledgerEntry = LedgerEntry.fromIndexData(indexData);
 
-                // Rebuild File containers
-                if (containerType.indexOf('_file') != -1) {
-                    // Multi-file containers
-                    if (containerType.indexOf('_multi') != -1) {
-                        if (containerAction.indexOf('setsinglecontent') != -1) {
-                            if (!decryptedContainers[containerName]) {
-                                decryptedContainers[containerName] = {};
-                            }
+            if (container != ledgerEntry.name) {
+                throw new Error(`Ledger data at index ${index} is not for container ${container}`);
+            }
 
-                            if (subFile) {
-                                if (subFile === indexData.params.fileName) {
-                                    decryptedContainers[containerName][subFile] = indexData.params.blob;
-                                    foundApplicableData = true;
-                                }
-                            } else {
-                                decryptedContainers[containerName][indexData.params.fileName] = indexData.params.blob;
-                                foundApplicableData = true;
-                            }
-                        }
+            [foundApplicableData, decryptedContainers] = ExternalFileLedgerContainer.getFileContent(
+                ledgerEntry,
+                indexData,
+                decryptedContainers,
+                subFile,
+            );
+        }
+
+        // Otherwise we'll have to rebuild one by one
+        else {
+            for (let desiredIndex = 1; desiredIndex <= index && desiredIndex < this.nextIndex; desiredIndex++) {
+                let foundApplicableDataAtIndex = false;
+                let indexData = await this.decryptContents(user, this.paddedIndex(+desiredIndex));
+                indexData = JSON.parse(indexData);
+
+                ledgerEntry = LedgerEntry.fromIndexData(indexData);
+
+                if (!container || ledgerEntry.name === container) {
+                    // Rebuild File containers
+                    if (ledgerEntry.isFileContainer()) {
+                        [foundApplicableDataAtIndex, decryptedContainers] = ExternalFileLedgerContainer.getFileContent(
+                            ledgerEntry,
+                            indexData,
+                            decryptedContainers,
+                            subFile,
+                        );
                     }
 
-                    // Single-file containers
-                    else {
-                        if (containerAction.indexOf('setcontents') != -1) {
-                            decryptedContainers[containerName] = indexData.params;
-                            foundApplicableData = true;
+                    // Rebuild List containers
+                    else if (ledgerEntry.isListContainer()) {
+                        if (!decryptedContainers[container]) {
+                            decryptedContainers[container] = [];
+                        }
+                        if (ledgerEntry.isListAppendAction()) {
+                            decryptedContainers[container].push(indexData.params);
+                            foundApplicableDataAtIndex = true;
                         }
                     }
                 }
 
-                // Rebuild List containers
-                else if (containerType.indexOf('_list') != -1) {
-                    if (!decryptedContainers[containerName]) {
-                        decryptedContainers[containerName] = [];
-                    }
-                    if (containerAction.indexOf('append') != -1) {
-                        decryptedContainers[containerName].push(indexData.params);
-                        foundApplicableData = true;
-                    }
-                }
+                foundApplicableData = foundApplicableData || foundApplicableDataAtIndex;
             }
         }
 
         if (!foundApplicableData) {
-            throw new Error(`No data found for date`);
+            throw new Error(`No data found at specific sequence`);
         }
 
         return decryptedContainers;
@@ -1100,14 +1190,18 @@ export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
             }
         }
 
-        if (toIndex != -1) {
+        if (toIndex == -1) {
+            throw new Error(`No data found for date`);
+        }
+
+        try {
             return {
                 on_date: onDate,
                 ...(await this.decryptToIndex(user, container, toIndex, subFile)),
             };
+        } catch (err) {
+            throw new Error(`No data found for date`);
         }
-
-        throw new Error('No data found for date');
     }
 
     async buildMetadata(author: Wallet) {

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -144,7 +144,7 @@ export class Vault {
         await ledger.addIndexedEntry(author, payload);
     }
 
-    async getHistoricalData(author: Wallet, container: string = null, date: string, subFile?: string) {
+    async getHistoricalDataByDate(author: Wallet, container: string = null, date: string, subFile?: string) {
         return await this.containers[Vault.LEDGER_CONTAINER].decryptToDate(author, container, date, subFile);
     }
 

--- a/src/vaults/Vault.ts
+++ b/src/vaults/Vault.ts
@@ -146,6 +146,16 @@ export class Vault {
         await ledger.addIndexedEntry(author, payload);
     }
 
+    async getHistoricalDataBySequence(author: Wallet, container: string = null, sequence: number, subFile?: string) {
+        return await this.containers[Vault.LEDGER_CONTAINER].decryptToIndex(
+            author,
+            container,
+            sequence,
+            subFile,
+            false,
+        );
+    }
+
     async getHistoricalDataByDate(author: Wallet, container: string = null, date: string, subFile?: string) {
         return await this.containers[Vault.LEDGER_CONTAINER].decryptToDate(author, container, date, subFile);
     }
@@ -1041,6 +1051,7 @@ export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
     }
 
     private paddedIndex(index: number = this.nextIndex): string {
+        // 9007199254740991 Max Safe Integer
         let paddedIndex: string = index + '';
         while (paddedIndex.length < ExternalFileLedgerContainer.INDEX_PADDING) {
             paddedIndex = '0' + paddedIndex;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1111,6 +1111,11 @@ commander@~2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
 
+compare-versions@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/compare-versions/-/compare-versions-3.5.0.tgz#85fc22a1ae9612ff730d77fb092295acd056d311"
+  integrity sha512-hX+4kt2Rcwu+x1U0SsEFCn1quURjEjPEGH/cPBlpME/IidGimAdwfMU+B+xDr7et/KTR7VH2+ZqWGerv4NGs2w==
+
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"


### PR DESCRIPTION
In order to support a new vault container type which will link across vaults, we need a more precise way to link to a revision of data within a vault.  As the ledger already contains a sequential index we can utilize this to perform a precise lookup of the data.

At the RPC level there are no new endpoints, however the existing LoadVault Historical retrieval methods have been modified to lookup via a Date or a Sequence.  As such, the `date` is no longer a required parameter and has been changed to an argument mutually exclusive with the new `sequence` parameter.