### PR TITLE
Return Vault Revision after Modification

### DIFF
--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -380,6 +380,7 @@ export const RPCVaultTests = async function() {
                 });
                 expect(result.success).toBeTruthy();
                 expect(result.vault_signed).toBeDefined();
+                expect(result.vault_revision).toEqual(1);
                 expect(fs.existsSync(`./${testableLocalVaultId}/tracking/20180101.json`)).toBeTruthy();
             } catch (err) {
                 fail(`Should not have thrown [${err}]`);
@@ -619,6 +620,7 @@ export const RPCVaultTests = async function() {
                 });
                 expect(result.success).toBeTruthy();
                 expect(result.vault_signed).toBeDefined();
+                expect(result.vault_revision).toEqual(2);
             } catch (err) {
                 fail(`Should not have thrown [${err}]`);
             }
@@ -845,6 +847,7 @@ export const RPCVaultTests = async function() {
                 });
                 expect(result.success).toBeTruthy();
                 expect(result.vault_signed).toBeDefined();
+                expect(result.vault_revision).toEqual(3);
                 expect(fs.existsSync(`./${testableLocalVaultId}/documents/test.png.json`)).toBeTruthy();
             } catch (err) {
                 fail(`Should not have thrown [${err}]`);
@@ -1166,6 +1169,7 @@ export const RPCVaultTests = async function() {
                 });
                 expect(result.success).toBeTruthy();
                 expect(result.vault_signed).toBeDefined();
+                expect(result.vault_revision).toEqual(4);
                 expect(fs.existsSync(`./${testableLocalVaultId}/documents/s3png.png.json`)).toBeTruthy();
 
                 const getResult: any = await CallRPCMethod(RPCVault.GetDocument, {
@@ -1202,6 +1206,7 @@ export const RPCVaultTests = async function() {
                 });
                 expect(result.success).toBeTruthy();
                 expect(result.vault_signed).toBeDefined();
+                expect(result.vault_revision).toEqual(5);
                 expect(fs.existsSync(`./${testableLocalVaultId}/documents/s3octet.png.json`)).toBeTruthy();
 
                 const getResult: any = await CallRPCMethod(RPCVault.GetDocument, {

--- a/rpc/vault.ts
+++ b/rpc/vault.ts
@@ -46,12 +46,12 @@ export class RPCVault {
             await vault.authorize(shipperWallet, LoadVault.OWNERS_ROLE, carrierWallet.public_key);
         }
 
-        const signature = await vault.writeMetadata(shipperWallet);
+        const vaultWriteResponse = await vault.writeMetadata(shipperWallet);
 
         return {
+            ...vaultWriteResponse,
             success: true,
             vault_id: vault.id,
-            vault_signed: signature,
             vault_uri: vault.getVaultMetaFileUri(),
         };
     }
@@ -91,11 +91,11 @@ export class RPCVault {
         const load = new LoadVault(storage, args.vault);
 
         await load.addTrackingData(wallet, args.payload);
-        const signature = await load.writeMetadata(wallet);
+        const vaultWriteResponse = await load.writeMetadata(wallet);
 
         return {
+            ...vaultWriteResponse,
             success: true,
-            vault_signed: signature,
         };
     }
 
@@ -136,11 +136,11 @@ export class RPCVault {
         const load = new LoadVault(storage, args.vault);
 
         await load.addShipmentData(wallet, args.shipment);
-        const signature = await load.writeMetadata(wallet);
+        const vaultWriteResponse = await load.writeMetadata(wallet);
 
         return {
+            ...vaultWriteResponse,
             success: true,
-            vault_signed: signature,
         };
     }
 
@@ -180,11 +180,11 @@ export class RPCVault {
         const load = new LoadVault(storage, args.vault);
 
         await load.addDocument(wallet, args.documentName, args.documentContent);
-        const signature = await load.writeMetadata(wallet);
+        const vaultWriteResponse = await load.writeMetadata(wallet);
 
         return {
+            ...vaultWriteResponse,
             success: true,
-            vault_signed: signature,
         };
     }
 
@@ -204,11 +204,11 @@ export class RPCVault {
         const documentContent = await RPCVault.getFileFromS3(args.bucket, args.key);
 
         await load.addDocument(wallet, args.documentName, documentContent);
-        const signature = await load.writeMetadata(wallet);
+        const vaultWriteResponse = await load.writeMetadata(wallet);
 
         return {
+            ...vaultWriteResponse,
             success: true,
-            vault_signed: signature,
         };
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,7 +58,15 @@ export function objectHash(obj: any, at?: Date, alg?: string) {
     return stringHash(s_cleaned + s_at, alg);
 }
 
-export function objectSignature(author, obj, at?) {
+export interface Signature {
+    author: string;
+    hash: string;
+    at: string;
+    signature: string;
+    alg: string;
+}
+
+export function objectSignature(author, obj, at?): Signature {
     at = at || new Date();
     const hash = objectHash(obj, at, obj.signature && obj.signed.alg ? obj.signed.alg : DEFAULT_HASH_ALG);
 

--- a/src/vaults/containers/LedgerContainer.ts
+++ b/src/vaults/containers/LedgerContainer.ts
@@ -73,7 +73,7 @@ class LedgerEntry {
 export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
     public container_type: string = 'external_file_ledger';
     private nextIndex: number;
-    private static readonly INDEX_PADDING: number = 7;
+    private static readonly INDEX_PADDING: number = 16;
     public static readonly MOMENT_FORMAT: string = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
     constructor(vault: Vault, name: string, meta?: any) {
@@ -83,6 +83,10 @@ export class ExternalFileLedgerContainer extends ExternalFileMultiContainer {
 
     private paddedIndex(index: number = this.nextIndex): string {
         // 9007199254740991 Max Safe Integer
+        if (index === Number.MAX_SAFE_INTEGER) {
+            throw new Error(`Vault max size reached [index: ${index}]`);
+        }
+
         let paddedIndex: string = index + '';
         while (paddedIndex.length < ExternalFileLedgerContainer.INDEX_PADDING) {
             paddedIndex = '0' + paddedIndex;


### PR DESCRIPTION
New Vault Links require the Vault Revision to access specific data at a point in the Vault's history.  To properly support this, any vault modification (add to a container) needs to return the revision for that action.  This update includes a new `vault_revision` property in the response to any vault modification request.

```JS
{
    "jsonrpc": "2.0",
    "result": {
        "vault_signed": {
            "author": "687962.....d0a048572",
            "hash": "0x5b857d.....1bddb",
            "at": "2019-07-17T16:02:28.559Z",
            "signature": "0xa7af52da9.....fc96531c",
            "alg": "sha256"
        },
        "vault_revision": 3,
        "success": true
    },
    "id": 0
}
```