### PR TITLE
Migrate to Jayson from json-rpc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "fast-json-stable-stringify": "^2.0.0",
     "forever": "^1.0.0",
     "influx": "^5.0.7",
-    "json-rpc2": "^1.0.2",
+    "jayson": "^3.0.2",
     "mkdirp": "^0.5.1",
     "moment": "^2.22.2",
     "pg": "^7.6.1",

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -139,26 +139,6 @@ const methods = {
         "list": RPCWallet.List,
         "balance": RPCWallet.Balance,
     },
-
-    // Self-documenting Help method to display RPCOptions for each endpoint
-    "help": new Method({
-        handler: (args, callback) => {
-            if (args && args.namespace) {
-                callback(null, Object.assign(
-                    {},
-                    ...[].concat(
-                        ...Object.keys(helpMap).map((k: string) => {
-                            if(k.match(`^${args.namespace}`)) {
-                                return ({[k]: helpMap[k]})
-                            }
-                        })
-                    )
-                ));
-            } else {
-                callback(null, helpMap);
-            }
-        }
-    }),
 };
 
 // Jayson requires a flat object of methods
@@ -194,18 +174,35 @@ const server = new Server(methodMap, {
     collect: false // don't collect params in a single argument
 });
 
-// const server = rpc.Server.$create({
-//     "websocket": true, // is true by default
-//     "headers": { // allow custom headers is empty by default
-//         "Access-Control-Allow-Origin": "*"
-//     }
-// });
-//
-// server.on("error", function(err) {
-//     logger.error(`${err}`);
-// });
-//
-//
+// Self-Documenting Help response
+// ------------------------------
+server.method('help', new Method({
+    handler: (args, callback) => {
+        if (args && args.namespace) {
+            callback(null, Object.assign(
+                {},
+                ...[].concat(
+                    ...Object.keys(helpMap).map((k: string) => {
+                        if(k.match(`^${args.namespace}`)) {
+                            return ({[k]: helpMap[k]})
+                        }
+                    })
+                )
+            ));
+        } else {
+            callback(null, helpMap);
+        }
+    }
+}));
+
+// Error event logger setup
+// ------------------------
+// @ts-ignore
+server.on('response', (args, response) => {
+    if (response && response.error && response.error.message) {
+        logger.error(`${response.error.message}`);
+    }
+});
 
 // Build Schema Validators
 // Connect to TypeORM

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -44,152 +44,168 @@ import { GasPriceOracle } from "./src/GasPriceOracle";
 import {ShipChainEncryptorContainer} from "./src/shipchain/ShipChainEncryptorContainer"
 
 const typeorm = require("typeorm");
-const rpc = require("json-rpc2");
 const config = require('config');
+import { Server, Method } from 'jayson';
 
 
 const metrics = MetricsReporter.Instance;
 const PORT = config.get("RPC_SERVER_PORT");
 
-const RpcNamespaces = {};
 
-rpc.Endpoint.$include({
-    'expose': function($super, namespace, handlers){
+// Map RPC Method Handlers to namespaces
+// -------------------------------------
+const methods = {
+    "event": {
+        "subscribe": RPCEvent.Subscribe,
+        "unsubscribe": RPCEvent.Unsubscribe,
+    },
+    "load": {
+        "create_shipment_tx": RPCLoad_1_1_0.CreateShipmentTx,
+        "1.1.0": {
+            // Transactional methods
+            "create_shipment_tx": RPCLoad_1_1_0.CreateShipmentTx,
+            "set_vault_uri_tx": RPCLoad_1_1_0.SetVaultUriTx,
+            "set_vault_hash_tx": RPCLoad_1_1_0.SetVaultHashTx,
+            "set_carrier_tx": RPCLoad_1_1_0.SetCarrierTx,
+            "set_moderator_tx": RPCLoad_1_1_0.SetModeratorTx,
+            "set_in_progress_tx": RPCLoad_1_1_0.SetInProgressTx,
+            "set_complete_tx": RPCLoad_1_1_0.SetCompleteTx,
+            "set_canceled_tx": RPCLoad_1_1_0.SetCanceledTx,
+            "fund_escrow_tx": RPCLoad_1_1_0.FundEscrowTx,
+            "fund_escrow_ether_tx": RPCLoad_1_1_0.FundEscrowEtherTx,
+            "fund_escrow_ship_tx": RPCLoad_1_1_0.FundEscrowShipTx,
+            "release_escrow_tx": RPCLoad_1_1_0.ReleaseEscrowTx,
+            "withdraw_escrow_tx": RPCLoad_1_1_0.WithdrawEscrowTx,
+            "refund_escrow_tx": RPCLoad_1_1_0.RefundEscrowTx,
+            // View methods
+            "get_shipment_data": RPCLoad_1_1_0.GetShipmentData,
+            "get_escrow_data": RPCLoad_1_1_0.GetEscrowData,
+        },
+        "1.0.2": {
+            "create_shipment_transaction": RPCLoad_1_0_2.CreateShipmentTx,
+            "update_vault_hash_transaction": RPCLoad_1_0_2.UpdateVaultHashTx,
+            "fund_eth_transaction": RPCLoad_1_0_2.FundEthTx,
+            "fund_cash_transaction": RPCLoad_1_0_2.FundCashTx,
+            "fund_ship_transaction": RPCLoad_1_0_2.FundShipTx,
+            "commit_to_shipment_transaction": RPCLoad_1_0_2.CommitToShipmentTx,
+            "shipment_in_transit_transaction": RPCLoad_1_0_2.ShipmentInTransitTx,
+            "carrier_complete_transaction": RPCLoad_1_0_2.CarrierCompleteTx,
+            "shipper_accept_transaction": RPCLoad_1_0_2.ShipperAcceptTx,
+            "shipper_cancel_transaction": RPCLoad_1_0_2.ShipperCancelTx,
+            "pay_out_transaction": RPCLoad_1_0_2.PayOutTx,
+            "get_shipment_details": RPCLoad_1_0_2.GetShipmentDetails,
+            "get_shipment_details_continued": RPCLoad_1_0_2.GetShipmentDetailsContinued,
+            "get_escrow_status": RPCLoad_1_0_2.GetEscrowStatus,
+            "get_contract_flags": RPCLoad_1_0_2.GetContractFlags,
+        },
+    },
+    "storage_credentials": {
+        "create_hosted": RPCStorageCredentials.Create,
+        "validate_create": RPCStorageCredentials.TestAndStore,
+        "list": RPCStorageCredentials.List,
+        "test": RPCStorageCredentials.TestConnectivity,
+        "update": RPCStorageCredentials.Update,
+    },
+    "transaction": {
+        "sign": RPCTransaction.Sign,
+        "send": RPCTransaction.Send,
+    },
+    // Backwards Compatible LOAD Vault
+    "vault": {
+        "create": RPCVault.CreateVault,
+        "get_tracking": RPCVault.GetTrackingData,
+        "add_tracking": RPCVault.AddTrackingData,
+        "get_shipment": RPCVault.GetShipmentData,
+        "add_shipment": RPCVault.AddShipmentData,
+        "get_document": RPCVault.GetDocument,
+        "add_document": RPCVault.AddDocument,
+        "add_document_from_s3": RPCVault.AddDocumentFromS3,
+        "put_document_in_s3": RPCVault.PutDocumentInS3,
+        "list_documents": RPCVault.ListDocuments,
+        "verify": RPCVault.VerifyVault,
+        "get_historical_shipment_data": RPCVault.GetHistoricalShipmentData,
+        "get_historical_tracking_data": RPCVault.GetHistoricalTrackingData,
+        "get_historical_document": RPCVault.GetHistoricalDocument,
+    },
+    // New namespace to handle many different vaults
+    "vaults": {
+        "linked": {
+            "get_linked_data": RPCVault.GetLinkedData,
+        },
+    },
+    "wallet": {
+        "create_hosted": RPCWallet.Create,
+        "import_hosted": RPCWallet.Import,
+        "list": RPCWallet.List,
+        "balance": RPCWallet.Balance,
+    },
 
-        if(namespace !== 'help') {
-            if (!RpcNamespaces[namespace]) {
-                RpcNamespaces[namespace] = {};
-            }
-
-            for (let method of Object.keys(handlers)) {
-                logger.silly(`Registering RPC Method '${namespace}.${method}'`);
-                const mtd = Object.getOwnPropertyDescriptor(handlers, method);
-
-                // The RPCMethod function decorator adds its parameter check options
-                // as a new key in the PropertyDescriptor of the function itself
-                const rpcMethodOptions = Object.getOwnPropertyDescriptor(mtd.value, 'rpcOptions');
-
-                RpcNamespaces[namespace][method] = rpcMethodOptions.value || {};
+    // Self-documenting Help method to display RPCOptions for each endpoint
+    "help": new Method({
+        handler: (args, callback) => {
+            if (args && args.namespace) {
+                callback(null, Object.assign(
+                    {},
+                    ...[].concat(
+                        ...Object.keys(helpMap).map((k: string) => {
+                            if(k.match(`^${args.namespace}`)) {
+                                return ({[k]: helpMap[k]})
+                            }
+                        })
+                    )
+                ));
+            } else {
+                callback(null, helpMap);
             }
         }
+    }),
+};
 
-        $super(namespace, handlers);
-    }
+// Jayson requires a flat object of methods
+// ----------------------------------------
+const nestedName = (k, p) => p ? `${p}.${k}` : k;
+const methodMap = Object.assign(
+    {},
+    ...function _flatten(o, p) {
+        return [].concat(...Object.keys(o)
+            .map(k =>
+                typeof o[k] === 'object' && !(o[k] instanceof Method) ?
+                    _flatten(o[k], nestedName(k,p)) :
+                    ({[nestedName(k,p)]: o[k]})
+            )
+        );
+    }(methods)
+);
+
+// Collect RPCOptions for each method to be displayed as Help
+// ----------------------------------------------------------
+const helpMap = Object.assign(
+    {},
+    ...[].concat(
+        ...Object.keys(methodMap).map(k =>
+            ({[k]: methodMap[k].rpcOptions || {}})
+        )
+    )
+);
+
+// Build Jayson Server with flattened methodMap
+// --------------------------------------------
+const server = new Server(methodMap, {
+    collect: false // don't collect params in a single argument
 });
 
-
-const server = rpc.Server.$create({
-    "websocket": true, // is true by default
-    "headers": { // allow custom headers is empty by default
-        "Access-Control-Allow-Origin": "*"
-    }
-});
-
-server.on("error", function(err) {
-    logger.error(`${err}`);
-});
-
-
-// Expose RPC Method Handlers
-// ==========================
-server.expose("wallet", {
-    "create_hosted": RPCWallet.Create,
-    "import_hosted": RPCWallet.Import,
-    "list": RPCWallet.List,
-    "balance": RPCWallet.Balance,
-});
-
-server.expose("storage_credentials", {
-    "create_hosted": RPCStorageCredentials.Create,
-    "validate_create": RPCStorageCredentials.TestAndStore,
-    "list": RPCStorageCredentials.List,
-    "test": RPCStorageCredentials.TestConnectivity,
-    "update": RPCStorageCredentials.Update,
-});
-
-server.expose("transaction", {
-    "sign": RPCTransaction.Sign,
-    "send": RPCTransaction.Send,
-});
-
-server.expose("load", {
-    "create_shipment_tx": RPCLoad_1_1_0.CreateShipmentTx,
-});
-
-server.expose("load.1.1.0", {
-    // Transactional methods
-    "create_shipment_tx": RPCLoad_1_1_0.CreateShipmentTx,
-    "set_vault_uri_tx": RPCLoad_1_1_0.SetVaultUriTx,
-    "set_vault_hash_tx": RPCLoad_1_1_0.SetVaultHashTx,
-    "set_carrier_tx": RPCLoad_1_1_0.SetCarrierTx,
-    "set_moderator_tx": RPCLoad_1_1_0.SetModeratorTx,
-    "set_in_progress_tx": RPCLoad_1_1_0.SetInProgressTx,
-    "set_complete_tx": RPCLoad_1_1_0.SetCompleteTx,
-    "set_canceled_tx": RPCLoad_1_1_0.SetCanceledTx,
-    "fund_escrow_tx": RPCLoad_1_1_0.FundEscrowTx,
-    "fund_escrow_ether_tx": RPCLoad_1_1_0.FundEscrowEtherTx,
-    "fund_escrow_ship_tx": RPCLoad_1_1_0.FundEscrowShipTx,
-    "release_escrow_tx": RPCLoad_1_1_0.ReleaseEscrowTx,
-    "withdraw_escrow_tx": RPCLoad_1_1_0.WithdrawEscrowTx,
-    "refund_escrow_tx": RPCLoad_1_1_0.RefundEscrowTx,
-    // View methods
-    "get_shipment_data": RPCLoad_1_1_0.GetShipmentData,
-    "get_escrow_data": RPCLoad_1_1_0.GetEscrowData,
-});
-
-server.expose("load.1.0.2", {
-    "create_shipment_transaction": RPCLoad_1_0_2.CreateShipmentTx,
-    "update_vault_hash_transaction": RPCLoad_1_0_2.UpdateVaultHashTx,
-    "fund_eth_transaction": RPCLoad_1_0_2.FundEthTx,
-    "fund_cash_transaction": RPCLoad_1_0_2.FundCashTx,
-    "fund_ship_transaction": RPCLoad_1_0_2.FundShipTx,
-    "commit_to_shipment_transaction": RPCLoad_1_0_2.CommitToShipmentTx,
-    "shipment_in_transit_transaction": RPCLoad_1_0_2.ShipmentInTransitTx,
-    "carrier_complete_transaction": RPCLoad_1_0_2.CarrierCompleteTx,
-    "shipper_accept_transaction": RPCLoad_1_0_2.ShipperAcceptTx,
-    "shipper_cancel_transaction": RPCLoad_1_0_2.ShipperCancelTx,
-    "pay_out_transaction": RPCLoad_1_0_2.PayOutTx,
-    "get_shipment_details": RPCLoad_1_0_2.GetShipmentDetails,
-    "get_shipment_details_continued": RPCLoad_1_0_2.GetShipmentDetailsContinued,
-    "get_escrow_status": RPCLoad_1_0_2.GetEscrowStatus,
-    "get_contract_flags": RPCLoad_1_0_2.GetContractFlags,
-});
-
-server.expose("vault", {
-    "create": RPCVault.CreateVault,
-    "get_tracking": RPCVault.GetTrackingData,
-    "add_tracking": RPCVault.AddTrackingData,
-    "get_shipment": RPCVault.GetShipmentData,
-    "add_shipment": RPCVault.AddShipmentData,
-    "get_document": RPCVault.GetDocument,
-    "add_document": RPCVault.AddDocument,
-    "add_document_from_s3": RPCVault.AddDocumentFromS3,
-    "put_document_in_s3": RPCVault.PutDocumentInS3,
-    "list_documents": RPCVault.ListDocuments,
-    "verify": RPCVault.VerifyVault,
-    "get_historical_shipment_data": RPCVault.GetHistoricalShipmentData,
-    "get_historical_tracking_data": RPCVault.GetHistoricalTrackingData,
-    "get_historical_document": RPCVault.GetHistoricalDocument,
-});
-
-server.expose("vaults.linked", {
-    "get_linked_data": RPCVault.GetLinkedData,
-});
-
-server.expose("event", {
-    "subscribe": RPCEvent.Subscribe,
-    "unsubscribe": RPCEvent.Unsubscribe,
-});
-
-server.expose("help", (args, opt, callback) => {
-    if(args && args.namespace) {
-        let result = {};
-        result[args.namespace] = RpcNamespaces[args.namespace];
-        callback(null, result);
-    } else {
-        callback(null, RpcNamespaces);
-    }
-});
+// const server = rpc.Server.$create({
+//     "websocket": true, // is true by default
+//     "headers": { // allow custom headers is empty by default
+//         "Access-Control-Allow-Origin": "*"
+//     }
+// });
+//
+// server.on("error", function(err) {
+//     logger.error(`${err}`);
+// });
+//
+//
 
 // Build Schema Validators
 // Connect to TypeORM
@@ -218,7 +234,7 @@ async function startRpcServer() {
     metrics.countAction("startRpcServer");
 
     logger.info(`RPC server listening on ${PORT}`);
-    server.listen(PORT, "0.0.0.0");
+    server.http().listen(PORT);
 }
 
 startRpcServer().catch(err => {

--- a/rpc/__tests__/event.ts
+++ b/rpc/__tests__/event.ts
@@ -57,7 +57,7 @@ export const RPCEventTests = async function() {
                 });
                 fail('Did not Throw');
             } catch (err){
-                expect(err.message).toEqual('Contract \'not a project\' not registered');
+                expect(err.message).toContain('Contract \'not a project\' not registered');
             }
         }));
 
@@ -104,7 +104,7 @@ export const RPCEventTests = async function() {
                 });
                 fail('Did not Throw');
             } catch (err){
-                expect(err.message).toEqual('EventSubscription not found');
+                expect(err.message).toContain('EventSubscription not found');
             }
         }));
 

--- a/rpc/__tests__/storage_credentials.ts
+++ b/rpc/__tests__/storage_credentials.ts
@@ -82,7 +82,7 @@ export const RPCStorageCredentialsTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Driver type: INVALID, not allowed!');
+                expect(err.message).toContain('Driver type: INVALID, not allowed!');
             }
 
             expect(await StorageCredential.count()).toEqual(initialCount);
@@ -168,7 +168,7 @@ export const RPCStorageCredentialsTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Driver type: INVALID, not allowed!');
+                expect(err.message).toContain('Driver type: INVALID, not allowed!');
             }
 
             expect(await StorageCredential.count()).toEqual(initialCount);

--- a/rpc/__tests__/transaction.ts
+++ b/rpc/__tests__/transaction.ts
@@ -97,7 +97,7 @@ export const RPCTransactions = async function() {
                 });
                 fail('Did not Throw');
             } catch (err){
-                expect(err.message).toEqual('Invalid Ethereum Transaction format');
+                expect(err.message).toContain('Invalid Ethereum Transaction format');
             }
         }));
 
@@ -109,7 +109,7 @@ export const RPCTransactions = async function() {
                 });
                 fail('Did not Throw');
             } catch (err){
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -155,7 +155,7 @@ export const RPCTransactions = async function() {
                 });
                 fail('Did not Throw');
             } catch (err){
-                expect(err.message).toEqual('Invalid Ethereum Transaction format');
+                expect(err.message).toContain('Invalid Ethereum Transaction format');
             }
         }));
 

--- a/rpc/__tests__/utils.ts
+++ b/rpc/__tests__/utils.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Method } from 'jayson';
+
 // https://staxmanade.com/2015/11/testing-asyncronous-code-with-mochajs-and-es7-async-await/
 // Automatically wrap a test case with try/catch and call the async done() when it's complete
 export const mochaAsync = fn => {
@@ -151,7 +153,8 @@ const resolveCallback = (resolve: any, reject: any) => {
 // result of the RPC method or raises an error with the rejection of the promise
 export const CallRPCMethod = async (method: any, args: any = null): Promise<any> => {
     return new Promise((resolve, reject) => {
-        method(args, null, resolveCallback(resolve, reject))
+        const jaysonMethod: Method = method;
+        jaysonMethod.getHandler().call(null, ...[args, resolveCallback(resolve, reject)]);
     });
 };
 

--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -203,7 +203,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -216,7 +216,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -229,7 +229,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -310,7 +310,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -324,7 +324,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -338,7 +338,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -352,7 +352,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid Object: 'payload'`);
+                expect(err.message).toContain(`Invalid Object: 'payload'`);
             }
 
             try {
@@ -364,7 +364,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid Object: 'payload'`);
+                expect(err.message).toContain(`Invalid Object: 'payload'`);
             }
         }));
 
@@ -428,7 +428,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -441,7 +441,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -454,7 +454,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -531,7 +531,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -545,7 +545,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -559,7 +559,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -573,7 +573,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid Object: 'shipment'`);
+                expect(err.message).toContain(`Invalid Object: 'shipment'`);
             }
 
             try {
@@ -585,7 +585,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid Object: 'shipment'`);
+                expect(err.message).toContain(`Invalid Object: 'shipment'`);
             }
         }));
 
@@ -603,7 +603,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Shipment Invalid: data should NOT have additional properties`);
+                expect(err.message).toContain(`Shipment Invalid: data should NOT have additional properties`);
             }
         }));
 
@@ -667,7 +667,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -680,7 +680,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -693,7 +693,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -706,7 +706,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Container contents empty`);
+                expect(err.message).toContain(`Container contents empty`);
             }
         }));
 
@@ -772,7 +772,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -787,7 +787,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -802,7 +802,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -817,7 +817,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'documentName'`);
+                expect(err.message).toContain(`Invalid String: 'documentName'`);
             }
         }));
 
@@ -832,7 +832,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'documentContent'`);
+                expect(err.message).toContain(`Invalid String: 'documentContent'`);
             }
         }));
 
@@ -897,7 +897,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -911,7 +911,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -925,7 +925,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -939,7 +939,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'documentName'`);
+                expect(err.message).toContain(`Invalid String: 'documentName'`);
             }
         }));
 
@@ -953,7 +953,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unauthorized access to vault contents`);
+                expect(err.message).toContain(`Unauthorized access to vault contents`);
             }
         }));
 
@@ -1030,7 +1030,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'documentName'`);
+                expect(err.message).toContain(`Invalid String: 'documentName'`);
             }
         }));
 
@@ -1046,7 +1046,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'key'`);
+                expect(err.message).toContain(`Invalid String: 'key'`);
             }
         }));
 
@@ -1062,7 +1062,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'bucket'`);
+                expect(err.message).toContain(`Invalid String: 'bucket'`);
             }
         }));
 
@@ -1078,7 +1078,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -1094,7 +1094,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -1119,7 +1119,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -1144,7 +1144,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('S3 Read File: File Not Found [Mocked failure]');
+                expect(err.message).toContain('S3 Read File: File Not Found [Mocked failure]');
             }
         }));
 
@@ -1277,7 +1277,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'documentName'`);
+                expect(err.message).toContain(`Invalid String: 'documentName'`);
             }
         }));
 
@@ -1293,7 +1293,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'key'`);
+                expect(err.message).toContain(`Invalid String: 'key'`);
             }
         }));
 
@@ -1309,7 +1309,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'bucket'`);
+                expect(err.message).toContain(`Invalid String: 'bucket'`);
             }
         }));
 
@@ -1325,7 +1325,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -1341,7 +1341,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -1366,7 +1366,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -1391,7 +1391,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Unauthorized access to vault contents');
+                expect(err.message).toContain('Unauthorized access to vault contents');
             }
         }));
 
@@ -1416,7 +1416,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Write File to s3: File Not Found [Mocked failure]');
+                expect(err.message).toContain('Write File to s3: File Not Found [Mocked failure]');
             }
         }));
 
@@ -1492,7 +1492,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -1504,7 +1504,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -1579,7 +1579,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -1591,7 +1591,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -1723,7 +1723,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -1737,7 +1737,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -1751,7 +1751,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -1765,7 +1765,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`No data found for date`);
+                expect(err.message).toContain(`No data found for date`);
             }
         }));
 
@@ -1853,7 +1853,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Ledger data at index 1 is not for container shipment`);
+                expect(err.message).toContain(`Ledger data at index 1 is not for container shipment`);
             }
         }));
 
@@ -2014,7 +2014,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -2028,7 +2028,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -2042,7 +2042,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -2056,7 +2056,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`No data found for date`);
+                expect(err.message).toContain(`No data found for date`);
             }
         }));
 
@@ -2143,7 +2143,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`No data found at specific sequence`);
+                expect(err.message).toContain(`No data found at specific sequence`);
             }
         }));
 
@@ -2305,7 +2305,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Invalid String: 'documentName'`);
+                expect(err.message).toContain(`Invalid String: 'documentName'`);
             }
         }));
 
@@ -2319,7 +2319,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('StorageCredentials not found');
+                expect(err.message).toContain('StorageCredentials not found');
             }
         }));
 
@@ -2333,7 +2333,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('Wallet not found');
+                expect(err.message).toContain('Wallet not found');
             }
         }));
 
@@ -2347,7 +2347,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Unable to load vault from Storage driver 'File Not Found'`);
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
             }
         }));
 
@@ -2361,7 +2361,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`No data found for date`);
+                expect(err.message).toContain(`No data found for date`);
             }
         }));
 
@@ -2474,7 +2474,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`No data found for date`);
+                expect(err.message).toContain(`No data found for date`);
             }
         }));
 
@@ -2490,7 +2490,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`Ledger data at index 1 is not for container documents`);
+                expect(err.message).toContain(`Ledger data at index 1 is not for container documents`);
             }
         }));
 
@@ -2506,7 +2506,7 @@ export const RPCVaultTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual(`No data found at specific sequence`);
+                expect(err.message).toContain(`No data found at specific sequence`);
             }
         }));
 

--- a/rpc/__tests__/wallet.ts
+++ b/rpc/__tests__/wallet.ts
@@ -83,7 +83,7 @@ export const RPCWalletTests = async function() {
                 });
                 fail("Did not Throw"); return;
             } catch (err) {
-                expect(err.message).toEqual('private key length is invalid');
+                expect(err.message).toContain('private key length is invalid');
             }
 
             expect(await Wallet.count()).toEqual(initialCount);

--- a/rpc/decorators.ts
+++ b/rpc/decorators.ts
@@ -17,13 +17,12 @@
 import { validateUuid } from './validators';
 import { MetricsReporter } from '../src/MetricsReporter';
 import { Logger } from '../src/Logger';
+import { Method, Server } from 'jayson';
 
 // Import Moment Typings and Functions
 import { Moment } from 'moment';
 import moment from 'moment';
 const MOMENT_FORMAT: string = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
-
-const rpc = require('json-rpc2');
 
 const logger = Logger.get(module.filename);
 const metrics = MetricsReporter.Instance;
@@ -107,33 +106,41 @@ export function RPCMethod(options?: RPCMethodOptions) {
         const originalMethod = descriptor.value;
 
         //editing the descriptor/value parameter
-        descriptor.value = function() {
-            let context = this;
+        descriptor.value = new Method({
+            handler: function(args:any, done:any) {
+                let context = this;
 
-            // We cannot check this at compile time due to the class-decorator not being
-            // fully applied yet while the methods are being defined within the class
-            if (!target.__isRpcClass) {
-                logger.error(
-                    `@RPCMethod '${propertyKey}' used outside of @RPCNamespace in '${target.name ||
-                        target.constructor.name}'`,
-                );
-            }
+                // We cannot check this at compile time due to the class-decorator not being
+                // fully applied yet while the methods are being defined within the class
+                if (!target.__isRpcClass) {
+                    logger.error(
+                        `@RPCMethod '${propertyKey}' used outside of @RPCNamespace in '${target.name ||
+                            target.constructor.name}'`,
+                    );
+                }
 
-            metrics.methodCall(target.__rpcNamespace + '.' + propertyKey);
+                metrics.methodCall(target.__rpcNamespace + '.' + propertyKey);
 
-            checkOptions(arguments, options);
+                try {
+                    checkOptions(arguments, options);
+                } catch (err) {
+                    done(err);
+                    return;
+                }
 
-            const callback = arguments[2];
-
-            logger.debug(`Invoking RPCMethod: '${propertyKey}' in '${target.name || target.constructor.name}'`);
-            originalMethod
-                .apply(context, arguments)
-                .then(resolve => callback(null, resolve))
-                .catch(reject => {
-                    metrics.methodFail(target.__rpcNamespace + '.' + propertyKey);
-                    callback(reject);
-                });
-        };
+                logger.debug(`Invoking RPCMethod: '${propertyKey}' in '${target.name || target.constructor.name}'`);
+                originalMethod
+                    .apply(context, arguments)
+                    .then(resolve => done(null, resolve))
+                    .catch(reject => {
+                        metrics.methodFail(target.__rpcNamespace + '.' + propertyKey);
+                        const errType = Server.errors.INVALID_REQUEST;
+                        const errMsg = Server.errorMessages[errType];
+                        const err = Server.prototype.error(errType, `${errMsg} [${reject}]`);
+                        done(err);
+                    });
+            },
+        });
 
         // Add the RPCMethod options that are validated as a property on the method
         Object.defineProperty(descriptor.value, 'rpcOptions', {
@@ -158,6 +165,12 @@ function checkOptions(args, options: RPCMethodOptions) {
     }
 }
 
+export function throwInvalidParams(message: string) {
+    const errType = Server.errors.INVALID_PARAMS;
+    const errMsg = Server.errorMessages[errType];
+    throw Server.prototype.error(errType, `${errMsg} [${message}]`);
+}
+
 function checkRequiredParameters(args, required: string[]) {
     let missing: string[] = [];
 
@@ -168,7 +181,7 @@ function checkRequiredParameters(args, required: string[]) {
     }
 
     if (missing.length > 0) {
-        throw new rpc.Error.InvalidParams(
+        throwInvalidParams(
             `Missing required parameter${missing.length === 1 ? '' : 's'}: '${missing.join(', ')}'`,
         );
     }
@@ -188,7 +201,7 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
     }
 
     if (failed.length > 0) {
-        throw new rpc.Error.InvalidParams(`Invalid UUID${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
+        throwInvalidParams(`Invalid UUID${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
     }
 
     // Check String format
@@ -202,7 +215,7 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
     }
 
     if (failed.length > 0) {
-        throw new rpc.Error.InvalidParams(`Invalid String${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
+        throwInvalidParams(`Invalid String${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
     }
 
     // Check Object format
@@ -224,7 +237,7 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
     }
 
     if (failed.length > 0) {
-        throw new rpc.Error.InvalidParams(`Invalid Object${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
+        throwInvalidParams(`Invalid Object${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
     }
 
     // Check Date format
@@ -245,7 +258,7 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
     }
 
     if (failed.length > 0) {
-        throw new rpc.Error.InvalidParams(`Invalid Date${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
+        throwInvalidParams(`Invalid Date${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
     }
 
     // Check Number format
@@ -261,7 +274,7 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
     }
 
     if (failed.length > 0) {
-        throw new rpc.Error.InvalidParams(`Invalid Number${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
+        throwInvalidParams(`Invalid Number${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
     }
 
     // Check Number format
@@ -279,7 +292,7 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
     }
 
     if (failed.length > 0) {
-        throw new rpc.Error.InvalidParams(
+        throwInvalidParams(
             `Invalid Parameter Combination${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`,
         );
     }

--- a/rpc/decorators.ts
+++ b/rpc/decorators.ts
@@ -107,7 +107,7 @@ export function RPCMethod(options?: RPCMethodOptions) {
 
         //editing the descriptor/value parameter
         descriptor.value = new Method({
-            handler: function(args:any, done:any) {
+            handler: function(args: any, done: any) {
                 let context = this;
 
                 // We cannot check this at compile time due to the class-decorator not being
@@ -181,9 +181,7 @@ function checkRequiredParameters(args, required: string[]) {
     }
 
     if (missing.length > 0) {
-        throwInvalidParams(
-            `Missing required parameter${missing.length === 1 ? '' : 's'}: '${missing.join(', ')}'`,
-        );
+        throwInvalidParams(`Missing required parameter${missing.length === 1 ? '' : 's'}: '${missing.join(', ')}'`);
     }
 }
 
@@ -292,8 +290,6 @@ function validateParameters(args, validations: RPCMethodValidateOptions) {
     }
 
     if (failed.length > 0) {
-        throwInvalidParams(
-            `Invalid Parameter Combination${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`,
-        );
+        throwInvalidParams(`Invalid Parameter Combination${failed.length === 1 ? '' : 's'}: '${failed.join(', ')}'`);
     }
 }

--- a/rpc/transaction.ts
+++ b/rpc/transaction.ts
@@ -19,7 +19,7 @@ import { BaseContract } from '../src/contracts/BaseContract';
 import { TransmissionConfirmationCallback } from '../src/shipchain/TransmissionConfirmationCallback';
 
 import { LoadedContracts } from './contracts';
-import { RPCMethod, RPCNamespace, throwInvalidParams } from "./decorators";
+import { RPCMethod, RPCNamespace, throwInvalidParams } from './decorators';
 
 const loadedContracts = LoadedContracts.Instance;
 

--- a/rpc/transaction.ts
+++ b/rpc/transaction.ts
@@ -14,14 +14,12 @@
  * limitations under the License.
  */
 
-const rpc = require('json-rpc2');
-
 import { Wallet } from '../src/entity/Wallet';
 import { BaseContract } from '../src/contracts/BaseContract';
 import { TransmissionConfirmationCallback } from '../src/shipchain/TransmissionConfirmationCallback';
 
 import { LoadedContracts } from './contracts';
-import { RPCMethod, RPCNamespace } from './decorators';
+import { RPCMethod, RPCNamespace, throwInvalidParams } from "./decorators";
 
 const loadedContracts = LoadedContracts.Instance;
 
@@ -36,7 +34,7 @@ export class RPCTransaction {
     public static async Sign(args) {
         if (typeof args.txUnsigned !== 'object') {
             // TODO: Validate arg as EthereumTx object
-            throw new rpc.Error.InvalidParams('Invalid Ethereum Transaction format');
+            throwInvalidParams('Invalid Ethereum Transaction format');
         }
 
         const signerWallet = await Wallet.getById(args.signerWallet);
@@ -53,7 +51,7 @@ export class RPCTransaction {
     public static async Send(args) {
         if (typeof args.txSigned !== 'object') {
             // TODO: Validate arg as EthereumTx object
-            throw new rpc.Error.InvalidParams('Invalid Ethereum Transaction format');
+            throw throwInvalidParams('Invalid Ethereum Transaction format');
         }
 
         let callbacks = new TransmissionConfirmationCallback(args.callbackUrl);

--- a/rpc/transaction.ts
+++ b/rpc/transaction.ts
@@ -19,7 +19,7 @@ import { BaseContract } from '../src/contracts/BaseContract';
 import { TransmissionConfirmationCallback } from '../src/shipchain/TransmissionConfirmationCallback';
 
 import { LoadedContracts } from './contracts';
-import { RPCMethod, RPCNamespace, throwInvalidParams } from './decorators';
+import { RPCMethod, RPCNamespace } from './decorators';
 
 const loadedContracts = LoadedContracts.Instance;
 
@@ -34,7 +34,7 @@ export class RPCTransaction {
     public static async Sign(args) {
         if (typeof args.txUnsigned !== 'object') {
             // TODO: Validate arg as EthereumTx object
-            throwInvalidParams('Invalid Ethereum Transaction format');
+            throw new Error('Invalid Ethereum Transaction format');
         }
 
         const signerWallet = await Wallet.getById(args.signerWallet);
@@ -51,7 +51,7 @@ export class RPCTransaction {
     public static async Send(args) {
         if (typeof args.txSigned !== 'object') {
             // TODO: Validate arg as EthereumTx object
-            throw throwInvalidParams('Invalid Ethereum Transaction format');
+            throw new Error('Invalid Ethereum Transaction format');
         }
 
         let callbacks = new TransmissionConfirmationCallback(args.callbackUrl);

--- a/rpc/validators.ts
+++ b/rpc/validators.ts
@@ -15,8 +15,7 @@
  */
 
 import { Logger } from '../src/Logger';
-
-const rpc = require('json-rpc2');
+import { throwInvalidParams } from "./decorators";
 
 const logger = Logger.get(module.filename);
 
@@ -77,6 +76,6 @@ export function validateShipmentArgs(shipment) {
 
     let valid = shipmentValidator(shipment);
     if (!valid) {
-        throw new rpc.Error.InvalidParams('Shipment Invalid: ' + ajv.errorsText(shipmentValidator.errors));
+        throwInvalidParams('Shipment Invalid: ' + ajv.errorsText(shipmentValidator.errors));
     }
 }

--- a/rpc/validators.ts
+++ b/rpc/validators.ts
@@ -15,7 +15,6 @@
  */
 
 import { Logger } from '../src/Logger';
-import { throwInvalidParams } from "./decorators";
 
 const logger = Logger.get(module.filename);
 
@@ -76,6 +75,6 @@ export function validateShipmentArgs(shipment) {
 
     let valid = shipmentValidator(shipment);
     if (!valid) {
-        throwInvalidParams('Shipment Invalid: ' + ajv.errorsText(shipmentValidator.errors));
+        throw new Error('Shipment Invalid: ' + ajv.errorsText(shipmentValidator.errors));
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -47,6 +47,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.8.tgz#fe444203ecef1162348cd6deb76c62477b2cc6e9"
   integrity sha512-I4+DbJEhLEg4/vIy/2gkWDvXBOOtPKV9EnLhYjMoqxcRW+TTZtUftkHktz/a8suoD5mUL7m6ReLrkPvSsCQQmw==
 
+"@types/node@^10.3.5":
+  version "10.14.12"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.14.12.tgz#0eec3155a46e6c4db1f27c3e588a205f767d622f"
+  integrity sha512-QcAKpaO6nhHLlxWBvpc4WeLrTvPqlHOvaj0s5GriKkA1zq+bsFBPpfYCvQhLqLgYlIko8A9YrPdaMHCo5mBcpg==
+
 "@types/node@^8.0.7":
   version "8.10.49"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.10.49.tgz#f331afc5efed0796798e5591d6e0ece636969b7b"
@@ -89,6 +94,14 @@
   dependencies:
     lodash.unescape "4.0.1"
     semver "5.5.0"
+
+JSONStream@^1.3.1:
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.5.tgz#3208c1f08d3a4d99261ab64f92302bc15e111ca0"
+  integrity sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==
+  dependencies:
+    jsonparse "^1.2.0"
+    through ">=2.2.7 <3"
 
 abab@^2.0.0:
   version "2.0.0"
@@ -590,11 +603,6 @@ bcrypt-pbkdf@^1.0.0, bcrypt-pbkdf@^1.0.2:
   integrity sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
   dependencies:
     tweetnacl "^0.14.3"
-
-better-curry@1.x.x:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/better-curry/-/better-curry-1.6.0.tgz#38f716b24c8cee07a262abc41c22c314e20e3869"
-  integrity sha1-OPcWskyM7geiYqvEHCLDFOIOOGk=
 
 binary-extensions@^1.0.0:
   version "1.13.1"
@@ -1106,7 +1114,7 @@ commander@2.15.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.15.1.tgz#df46e867d0fc2aec66a34662b406a9ccafff5b0f"
   integrity sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==
 
-commander@~2.20.0:
+commander@^2.12.2, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -1282,13 +1290,6 @@ data-urls@^1.0.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-debug@2.x.x, debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
-  version "2.6.9"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
-  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
-  dependencies:
-    ms "2.0.0"
-
 debug@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
@@ -1302,6 +1303,13 @@ debug@4, debug@4.1.1, debug@^4.0.1, debug@^4.1.0:
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
+
+debug@^2.2.0, debug@^2.3.3, debug@^2.6.8, debug@^2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+  dependencies:
+    ms "2.0.0"
 
 debug@^3.1.0, debug@^3.2.6:
   version "3.2.6"
@@ -1625,13 +1633,6 @@ es-to-primitive@^1.2.0:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es5class@2.x.x:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/es5class/-/es5class-2.3.1.tgz#42c5c18a9016bcb0db28a4d340ebb831f55d1b66"
-  integrity sha1-QsXBipAWvLDbKKTTQOu4MfVdG2Y=
-  dependencies:
-    better-curry "1.x.x"
-
 es6-promise@3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-3.0.2.tgz#010d5858423a5f118979665f46486a95c6ee2bb6"
@@ -1913,11 +1914,6 @@ eventemitter2@0.4.14, eventemitter2@~0.4.14:
   resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-0.4.14.tgz#8f61b75cde012b2e9eb284d4545583b5643b61ab"
   integrity sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=
 
-eventemitter3@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.2.0.tgz#1c86991d816ad1e504750e73874224ecf3bec508"
-  integrity sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=
-
 eventemitter3@3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
@@ -2065,7 +2061,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-eyes@0.1.x, eyes@~0.1.8:
+eyes@0.1.x, eyes@^0.1.8, eyes@~0.1.8:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
   integrity sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A=
@@ -2094,13 +2090,6 @@ fast-safe-stringify@^2.0.4, fast-safe-stringify@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz#04b26106cc56681f51a044cfc0d76cf0008ac2c2"
   integrity sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg==
-
-faye-websocket@0.x.x:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/faye-websocket/-/faye-websocket-0.11.1.tgz#f0efe18c4f56e4f40afc7e06c719fd5ee6188f38"
-  integrity sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=
-  dependencies:
-    websocket-driver ">=0.5.1"
 
 fb-watchman@^2.0.0:
   version "2.0.0"
@@ -2646,11 +2635,6 @@ http-errors@1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
-
-http-parser-js@>=0.4.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.5.0.tgz#d65edbede84349d0dc30320815a15d39cc3cbbd8"
-  integrity sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==
 
 http-proxy-agent@^2.1.0:
   version "2.1.0"
@@ -3211,6 +3195,20 @@ istanbul-reports@^1.5.1:
   dependencies:
     handlebars "^4.0.3"
 
+jayson@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/jayson/-/jayson-3.0.2.tgz#3fdd1ba8d780fe4600d2f9aa80a8639f3a799b08"
+  integrity sha512-jru45VNl0S9tkwNxd9ZlAwAJpAFZaCTy9GVgPhDocCSs32bysslYTrbvTq/QrrFDLp2q6M81q3S6qxvS43AMPg==
+  dependencies:
+    "@types/node" "^10.3.5"
+    JSONStream "^1.3.1"
+    commander "^2.12.2"
+    es6-promisify "^5.0.0"
+    eyes "^0.1.8"
+    json-stringify-safe "^5.0.1"
+    lodash "^4.17.11"
+    uuid "^3.2.1"
+
 jest-changed-files@^23.4.2:
   version "23.4.2"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-23.4.2.tgz#1eed688370cd5eebafe4ae93d34bb3b64968fe83"
@@ -3609,19 +3607,6 @@ jsesc@^1.3.0:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
   integrity sha1-RsP+yMGJKxKwgz25vHYiF226s0s=
 
-json-rpc2@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json-rpc2/-/json-rpc2-1.0.2.tgz#eb77bd27b1df606c23702c4e35d4afc54742ae8d"
-  integrity sha1-63e9J7HfYGwjcCxONdSvxUdCro0=
-  dependencies:
-    debug "2.x.x"
-    es5class "2.x.x"
-    eventemitter3 "1.x.x"
-    faye-websocket "0.x.x"
-    jsonparse "1.x.x"
-    lodash "3.x.x"
-    object-assign "4.x"
-
 json-schema-traverse@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz#69f6a87d9513ab8bb8fe63bdb0979c448e684660"
@@ -3666,7 +3651,7 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonparse@1.x.x:
+jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
   integrity sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
@@ -3819,11 +3804,6 @@ lodash.unescape@4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/lodash.unescape/-/lodash.unescape-4.0.1.tgz#bf2249886ce514cda112fae9218cdc065211fc9c"
   integrity sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw=
-
-lodash@3.x.x:
-  version "3.10.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
-  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
 lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
@@ -4341,15 +4321,15 @@ oauth-sign@~0.9.0:
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
   integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
 
-object-assign@4.x, object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
-  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
-
 object-assign@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-3.0.0.tgz#9bedd5ca0897949bca47e7ff408062d549f587f2"
   integrity sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=
+
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+  integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
 object-copy@^0.1.0:
   version "0.1.0"
@@ -6069,7 +6049,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@2, through@^2.3.6, through@~2.3.4:
+through@2, "through@>=2.2.7 <3", through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -6440,7 +6420,7 @@ uuid@2.0.1:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-2.0.1.tgz#c2a30dedb3e535d72ccf82e343941a50ba8533ac"
   integrity sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=
 
-uuid@3.3.2, uuid@^3.3.2:
+uuid@3.3.2, uuid@^3.2.1, uuid@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
@@ -6719,19 +6699,6 @@ webidl-conversions@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
-
-websocket-driver@>=0.5.1:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.0.tgz#0caf9d2d755d93aee049d4bdd0d3fe2cca2a24eb"
-  integrity sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=
-  dependencies:
-    http-parser-js ">=0.4.0"
-    websocket-extensions ">=0.1.1"
-
-websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
-  integrity sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==
 
 websocket@^1.0.28:
   version "1.0.28"


### PR DESCRIPTION
The json-rpc2 package has not been updated in 4 years and appears to be abandoned.   The Jayson package is a much more popular package for implementing the JSON RPC spec and is still maintained.

Migrating to the Jayson package will resolve some security alerts due to old dependencies still in use by the json-rpc2 package.

The exposed RPC Endpoint requests and responses should be compatible between these two packages.  The only difference may be error message formatting.