### PR TITLE
Web3 option transactionConfirmationBlocks should be configurable per env

### DIFF
--- a/config/DEMO.ts
+++ b/config/DEMO.ts
@@ -8,4 +8,7 @@ export default {
         "ELASTICSEARCH": "info",
     },
     "USE_JS_ORM_ENTITIES": true,
+    "WEB3_OPTIONS": {
+        "TRANSACTION_CONFIRMATION_BLOCKS": 24,
+    },
 }

--- a/config/PROD.ts
+++ b/config/PROD.ts
@@ -10,4 +10,7 @@ export default {
         "ELASTICSEARCH": "info",
     },
     "USE_JS_ORM_ENTITIES": true,
+    "WEB3_OPTIONS": {
+        "TRANSACTION_CONFIRMATION_BLOCKS": 24,
+    },
 }

--- a/config/STAGE.ts
+++ b/config/STAGE.ts
@@ -8,4 +8,7 @@ export default {
         "ELASTICSEARCH": "info",
     },
     "USE_JS_ORM_ENTITIES": true,
+    "WEB3_OPTIONS": {
+        "TRANSACTION_CONFIRMATION_BLOCKS": 24,
+    },
 }

--- a/config/default.ts
+++ b/config/default.ts
@@ -18,4 +18,7 @@ export default {
     "REDIS_URL" : "redis://:redis_pass@redis_db:6379/1",
     "RPC_SERVER_PORT" : 2000,
     "USE_JS_ORM_ENTITIES": false,
+    "WEB3_OPTIONS": {
+        "TRANSACTION_CONFIRMATION_BLOCKS": 1,
+    },
 }

--- a/src/entity/Contract.ts
+++ b/src/entity/Contract.ts
@@ -39,6 +39,7 @@ const metrics = MetricsReporter.Instance;
 const gasPriceOracle = GasPriceOracle.Instance;
 
 const GETH_NODE = config.get('GETH_NODE');
+const TRANSACTION_CONFIRMATION_BLOCKS = config.get('WEB3_OPTIONS.TRANSACTION_CONFIRMATION_BLOCKS');
 
 @Entity()
 export class Project extends BaseEntity {
@@ -308,7 +309,7 @@ export class Network extends BaseEntity {
         if (this._driver) return this._driver;
         const web3Options = {
             transactionBlockTimeout: 50,
-            transactionConfirmationBlocks: 1,
+            transactionConfirmationBlocks: TRANSACTION_CONFIRMATION_BLOCKS,
             transactionPollingTimeout: 480,
         };
         this._driver = new Web3(GETH_NODE, null, web3Options);


### PR DESCRIPTION
Local Development and ShipChain's DEV environment do not create empty blocks.  The Default setting for Web3Options.transactionConfirmationBlocks is 1 to stay consistent with existing functionality.  Environments that are pointing to Ropsten, Rinkeby, and Mainnet will use the standard 24 blocks.