### PR TITLE
Increase timeout for RPC server

### DIFF
--- a/compose/nginx/nginx.conf
+++ b/compose/nginx/nginx.conf
@@ -23,5 +23,6 @@ server {
         proxy_set_header Connection 'upgrade';
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 300s;
     }
 }

--- a/config/default.ts
+++ b/config/default.ts
@@ -17,5 +17,6 @@ export default {
     },
     "REDIS_URL" : "redis://:redis_pass@redis_db:6379/1",
     "RPC_SERVER_PORT" : 2000,
+    "RPC_SERVER_TIMEOUT": 270,
     "USE_JS_ORM_ENTITIES": false,
 }

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -64,6 +64,7 @@ import { Server, Method } from 'jayson';
 
 const metrics = MetricsReporter.Instance;
 const PORT = config.get("RPC_SERVER_PORT");
+const TIMEOUT = config.get("RPC_SERVER_TIMEOUT");
 
 
 // Map RPC Method Handlers to namespaces
@@ -365,7 +366,8 @@ async function startRpcServer() {
     metrics.countAction("startRpcServer");
 
     logger.info(`RPC server listening on ${PORT}`);
-    server.http().listen(PORT);
+    let instance = server.http().listen(PORT);
+    instance.timeout = TIMEOUT * 1000
 }
 
 // Handler to close database connections


### PR DESCRIPTION
This PR includes changes to the timeout for both the nginx proxy and the Jayson RPC server. There is an added configuration value RPC_SERVER_TIMEOUT (seconds) that can be used to configure the request timeout of the RPC server. It is default to 4.5 minutes, 30 seconds shy of the nginx timeout.

The nginx timeout is set to 5 minutes.

Additionally, we could consider changing the client request timeout (defaults to 2 minutes) in `request-options.ts`, but this only affects EventSubscription callbacks, and I feel that 2min is sufficient for these.

I have tested the RPC_SERVER_TIMEOUT parameter locally by adding sleep()s to a few RPC methods and playing with the setting. Postman seemed to time out at exactly the configured time.