### PR TITLE
Telemetry container and Primitive

### DIFF
--- a/docs/LoadVault.md
+++ b/docs/LoadVault.md
@@ -96,6 +96,50 @@ Retrieving the existing data points in this container is performed via:
 }
 ```
 
+#### Telemetry Data Container
+
+One container in the vault is for logging generic sensor data over the length of the shipment.
+
+##### Add
+
+Appending new data points in this container is performed via:
+
+```JSON
+{
+  "method": "vault.add_telemetry",
+  "params": {
+    "storageCredentials": "a350758d-2dd8-4bab-b983-2390657bbc25",
+    "vaultWallet": "eea40c56-7674-43a5-8612-30abd98cf58b",
+    "vault": "2ed96ba9-26d4-4f26-b3da-c45562268480",
+    "payload": {
+      "sensor_id": "44444444-4444-4444-bbbb-bbbbbbbbbbbb",
+      "timestamp": "2019-01-01T00:00:00.000Z",
+      "value": "78.354",
+      "units": "kph"
+    }
+  },
+  "jsonrpc": "2.0",
+  "id": 0
+}
+```
+
+##### Retrieve
+
+Retrieving the existing data points in this container is performed via:
+
+```JSON
+{
+  "method": "vault.get_telemetry",
+  "params": {
+    "storageCredentials": "a350758d-2dd8-4bab-b983-2390657bbc25",
+    "vaultWallet": "eea40c56-7674-43a5-8612-30abd98cf58b",
+    "vault": "2ed96ba9-26d4-4f26-b3da-c45562268480"
+  },
+  "jsonrpc": "2.0",
+  "id": 0
+}
+```
+
 #### Shipment Data Container
 
 One container in the vault is for storing the associated
@@ -252,6 +296,7 @@ getting this prior data is handled via these RPC methods.
 
  - `get_historical_shipment_data`
  - `get_historical_tracking_data`
+-  `get_historical_telemetry_data`
  - `get_historical_document`
 
 These are called the same as their non-historical counterparts, except they require one of two

--- a/docs/Primitives.md
+++ b/docs/Primitives.md
@@ -159,3 +159,21 @@ other Primitives, it does not natively contain links to any other Primitives.
 
 Shipment `9f1577d0-229a-480b-8da1-25315d1a385c`, including 10,000 Widget Items, is linked to a list
 of locations that provide insight into the movements of the Shipment and in turn the linked Items.
+    
+### Telemetry
+
+Telemetry is the generic sensor data collected at various time intervals. Telemetry has been
+included in the ShipChain ecosystem to provide up-to-date sensor information regarding supply chain
+movements.
+
+Official Telemetry fields are defined in the
+[Schema](http://schema.shipchain.io/1.2.2/telemetry.json)
+
+Because Telemetry currently exists to provide supporting information regarding the state of other
+Primitives, it does not natively contain links to any other Primitives.
+
+##### Example Usage
+
+Shipment `9f1577d0-229a-480b-8da1-25315d1a385c`, including 10,000 Widget Items, is linked to a list
+of data collected from various sensors that provide insight into the state, condition, environment,
+etc. of the Shipment and in turn the linked Items.

--- a/jest.testOrder.ts
+++ b/jest.testOrder.ts
@@ -41,6 +41,7 @@ import { RPCItemListPrimitiveTests } from './rpc/__tests__/primitives/item_list'
 import { RPCProductPrimitiveTests } from './rpc/__tests__/primitives/product';
 import { RPCProductListPrimitiveTests } from './rpc/__tests__/primitives/product_list';
 import { RPCTrackingPrimitiveTests } from './rpc/__tests__/primitives/tracking';
+import { RPCTelemetryPrimitiveTests } from './rpc/__tests__/primitives/telemetry';
 import { RPCShipmentPrimitiveTests } from './rpc/__tests__/primitives/shipment';
 import { RPCShipmentListPrimitiveTests } from './rpc/__tests__/primitives/shipment_list';
 import { RPCProcurementPrimitiveTests } from './rpc/__tests__/primitives/procurement';
@@ -71,6 +72,7 @@ import { ItemListPrimitiveTests } from "./src/shipchain/__tests__/itemlist";
 import { ProductPrimitiveTests } from "./src/shipchain/__tests__/product";
 import { ProductListPrimitiveTests } from "./src/shipchain/__tests__/productlist";
 import { TrackingPrimitiveTests } from "./src/shipchain/__tests__/tracking";
+import { TelemetryPrimitiveTests } from "./src/shipchain/__tests__/telemetry";
 import { ShipmentPrimitiveTests } from "./src/shipchain/__tests__/shipment";
 import { ShipmentListPrimitiveTests } from "./src/shipchain/__tests__/shipmentlist";
 import { ProcurementPrimitiveTests } from "./src/shipchain/__tests__/procurement";
@@ -125,6 +127,7 @@ describe('RPC', async () => {
     describe('Product Primitive', RPCProductPrimitiveTests);
     describe('ProductList Primitive', RPCProductListPrimitiveTests);
     describe('Tracking Primitive', RPCTrackingPrimitiveTests);
+    describe('Telemetry Primitive', RPCTelemetryPrimitiveTests);
     describe('Shipment Primitive', RPCShipmentPrimitiveTests);
     describe('ShipmentList Primitive', RPCShipmentListPrimitiveTests);
     describe('Procurement Primitive', RPCProcurementPrimitiveTests);
@@ -197,6 +200,7 @@ describe('ShipChain', async () => {
     describe('Product Primitive', ProductPrimitiveTests);
     describe('ProductList Primitive', ProductListPrimitiveTests);
     describe('Tracking Primitive', TrackingPrimitiveTests);
+    describe('Telemetry Primitive', TelemetryPrimitiveTests);
     describe('Shipment Primitive', ShipmentPrimitiveTests);
     describe('ShipmentList Primitive', ShipmentListPrimitiveTests);
     describe('Procurement Primitive', ProcurementPrimitiveTests);

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -130,6 +130,8 @@ const methods = {
         create: RPCVault.CreateVault,
         get_tracking: RPCVault.GetTrackingData,
         add_tracking: RPCVault.AddTrackingData,
+        get_telemetry: RPCVault.GetTelemetryData,
+        add_telemetry: RPCVault.AddTelemetryData,
         get_shipment: RPCVault.GetShipmentData,
         add_shipment: RPCVault.AddShipmentData,
         get_document: RPCVault.GetDocument,

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -198,6 +198,10 @@ const methods = {
                     get: RPCShipment.GetTracking,
                     set: RPCShipment.SetTracking,
                 },
+                telemetry: {
+                    get: RPCShipment.GetTelemetry,
+                    set: RPCShipment.SetTelemetry,
+                },
                 items: {
                     list: RPCShipment.ListItems,
                     get: RPCShipment.GetItem,

--- a/rpc-server.ts
+++ b/rpc-server.ts
@@ -34,6 +34,7 @@ import { RPCShipChainVault } from "./rpc/shipchain_vault";
 import { RPCProcurement } from "./rpc/primitives/procurement";
 import { RPCShipment } from "./rpc/primitives/shipment";
 import { RPCTracking } from "./rpc/primitives/tracking";
+import { RPCTelemetry } from "./rpc/primitives/telemetry";
 import { RPCDocument } from "./rpc/primitives/document";
 import { RPCProduct } from "./rpc/primitives/product";
 import { RPCItem } from "./rpc/primitives/item";
@@ -213,6 +214,11 @@ const methods = {
             tracking: {
                 get: RPCTracking.Get,
                 add: RPCTracking.Add,
+            },
+            // Telemetry Primitive
+            telemetry: {
+                get: RPCTelemetry.Get,
+                add: RPCTelemetry.Add,
             },
             // Document Primitive
             document: {

--- a/rpc/Engine.postman_collection.json
+++ b/rpc/Engine.postman_collection.json
@@ -2705,6 +2705,85 @@
 									"_postman_isSubFolder": true
 								},
 								{
+									"name": "telemetry",
+									"item": [
+										{
+											"name": "shipment.telemetry.get",
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n\t\"method\": \"vaults.shipchain.shipment.telemetry.get\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+												},
+												"url": {
+													"raw": "{{engine_url}}",
+													"host": [
+														"{{engine_url}}"
+													]
+												}
+											},
+											"response": []
+										},
+										{
+											"name": "shipment.telemetry.set",
+											"request": {
+												"method": "POST",
+												"header": [
+													{
+														"key": "Content-Type",
+														"name": "Content-Type",
+														"type": "text",
+														"value": "application/json"
+													}
+												],
+												"body": {
+													"mode": "raw",
+													"raw": "{\n\t\"method\": \"vaults.shipchain.shipment.telemetry.set\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\",\n\t\t\"telemetryLink\": \"VAULTREF#{{engine_url}}/{{vault_id}}/{{storage_credential_id}}/{{wallet_id}}/Telemetry\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+												},
+												"url": {
+													"raw": "{{engine_url}}",
+													"host": [
+														"{{engine_url}}"
+													]
+												}
+											},
+											"response": []
+										}
+									],
+									"event": [
+										{
+											"listen": "prerequest",
+											"script": {
+												"id": "19cca427-8648-4795-a504-2c6e10bf0575",
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										},
+										{
+											"listen": "test",
+											"script": {
+												"id": "8c05d0da-97a1-4606-82d3-206058236d16",
+												"type": "text/javascript",
+												"exec": [
+													""
+												]
+											}
+										}
+									],
+									"protocolProfileBehavior": {},
+									"_postman_isSubFolder": true
+								},
+								{
 									"name": "items",
 									"item": [
 										{

--- a/rpc/Engine.postman_collection.json
+++ b/rpc/Engine.postman_collection.json
@@ -2980,6 +2980,85 @@
 							"_postman_isSubFolder": true
 						},
 						{
+							"name": "telemetry",
+							"item": [
+								{
+									"name": "telemetry.get",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"method\": \"vaults.shipchain.telemetry.get\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+										},
+										"url": {
+											"raw": "{{engine_url}}",
+											"host": [
+												"{{engine_url}}"
+											]
+										}
+									},
+									"response": []
+								},
+								{
+									"name": "telemetry.add",
+									"request": {
+										"method": "POST",
+										"header": [
+											{
+												"key": "Content-Type",
+												"name": "Content-Type",
+												"type": "text",
+												"value": "application/json"
+											}
+										],
+										"body": {
+											"mode": "raw",
+											"raw": "{\n\t\"method\": \"vaults.shipchain.telemetry.add\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\",\n\t\t\"payload\": {\n          \"sensor_id\": \"44444444-4444-4444-bbbb-bbbbbbbbbbbb\",\n          \"timestamp\": \"2019-01-01T00:00:00.000Z\",\n\t      \"value\": \"78.354\",\n\t      \"units\": \"kph\"\n\t    }\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+										},
+										"url": {
+											"raw": "{{engine_url}}",
+											"host": [
+												"{{engine_url}}"
+											]
+										}
+									},
+									"response": []
+								}
+							],
+							"event": [
+								{
+									"listen": "prerequest",
+									"script": {
+										"id": "f911625e-cfea-4baa-a45a-3008ef0ec8de",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								},
+								{
+									"listen": "test",
+									"script": {
+										"id": "85da6f25-e1ef-4a01-ab7c-8efbf197154d",
+										"type": "text/javascript",
+										"exec": [
+											""
+										]
+									}
+								}
+							],
+							"protocolProfileBehavior": {},
+							"_postman_isSubFolder": true
+						},
+						{
 							"name": "document",
 							"item": [
 								{
@@ -3827,7 +3906,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"method\": \"vaults.shipchain.inject\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\",\n\t\t\"primitives\": [\n\t\t\t\"Procurement\",\n\t\t\t\"Shipment\",\n\t\t\t\"Tracking\",\n\t\t\t\"Document\",\n\t\t\t\"Product\",\n\t\t\t\"Item\",\n\t\t\t\"ProcurementList\",\n\t\t\t\"ShipmentList\",\n\t\t\t\"DocumentList\",\n\t\t\t\"ProductList\",\n\t\t\t\"ItemList\"\n\t\t]\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+									"raw": "{\n\t\"method\": \"vaults.shipchain.inject\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\",\n\t\t\"primitives\": [\n\t\t\t\"Procurement\",\n\t\t\t\"Shipment\",\n\t\t\t\"Tracking\",\n\t\t\t\"Telemetry\",\n\t\t\t\"Document\",\n\t\t\t\"Product\",\n\t\t\t\"Item\",\n\t\t\t\"ProcurementList\",\n\t\t\t\"ShipmentList\",\n\t\t\t\"DocumentList\",\n\t\t\t\"ProductList\",\n\t\t\t\"ItemList\"\n\t\t]\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
 								},
 								"url": {
 									"raw": "{{engine_url}}",

--- a/rpc/Engine.postman_collection.json
+++ b/rpc/Engine.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "92a21ef6-3b8d-47a9-8ea9-a37a42286089",
+		"_postman_id": "7b8f74f6-6ab2-41a4-bc89-c70e69f16a71",
 		"name": "Engine copy",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -542,6 +542,52 @@
 						"body": {
 							"mode": "raw",
 							"raw": "{\n\t\"method\": \"vault.get_tracking\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "{{engine_url}}",
+							"host": [
+								"{{engine_url}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "vault.add_telemetry_data",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"vault.add_telemetry\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\",\n\t    \"payload\": {\n          \"sensor_id\": \"a3b7c510-aac2-401e-9fdc-19b0b059cc37\",\n          \"timestamp\": \"2018-01-01T00:00:00.000S\",\n\t      \"value\": \"78.354\",\n\t      \"units\": \"kph\"\n\t    }\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
+						},
+						"url": {
+							"raw": "{{engine_url}}",
+							"host": [
+								"{{engine_url}}"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "vault.get_telemetry_data",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"method\": \"vault.get_telemetry\",\n\t\"params\": {\n\t\t\"storageCredentials\": \"{{storage_credential_id}}\",\n\t\t\"vaultWallet\": \"{{wallet_id}}\",\n\t\t\"vault\": \"{{vault_id}}\"\n\t},\n\t\"jsonrpc\": \"2.0\",\n\t\"id\": 0\n}"
 						},
 						"url": {
 							"raw": "{{engine_url}}",

--- a/rpc/__tests__/primitives/telemetry.ts
+++ b/rpc/__tests__/primitives/telemetry.ts
@@ -1,0 +1,330 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+
+
+require('../../../src/__tests__/testLoggingConfig');
+
+import 'mocha';
+import * as typeorm from "typeorm";
+import {
+    mochaAsync,
+    expectMissingRequiredParams,
+    expectInvalidUUIDParams,
+    expectInvalidObjectParams,
+    cleanupEntities,
+    CallRPCMethod,
+} from "../utils";
+
+import { buildSchemaValidators } from "../../validators";
+import { RPCShipChainVault } from '../../shipchain_vault';
+import { RPCTelemetry } from '../../primitives/telemetry';
+import { uuidv4 } from "../../../src/utils";
+import { StorageCredential } from "../../../src/entity/StorageCredential";
+import { Wallet } from "../../../src/entity/Wallet";
+import { EncryptorContainer } from '../../../src/entity/encryption/EncryptorContainer';
+import { getPrimitiveData } from "./utils";
+
+const DATE_1 = '2018-01-01T01:00:00.000Z';
+
+export const RPCTelemetryPrimitiveTests = async function() {
+    const RealDate = Date;
+
+    function mockDate(isoDate) {
+        // @ts-ignore
+        global.Date = class extends RealDate {
+            constructor() {
+                super();
+                return new RealDate(isoDate);
+            }
+        };
+    }
+
+    function resetDate() {
+        // @ts-ignore
+        global.Date = RealDate;
+    }
+
+    let fullWallet1;
+    let fullWallet2;
+    let localStorage;
+    let vaultId;
+
+    beforeAll(async () => {
+        await EncryptorContainer.init();
+
+        // Import known funded wallets
+        fullWallet1 = await Wallet.import_entity('0x0000000000000000000000000000000000000000000000000000000000000001');
+        await fullWallet1.save();
+        fullWallet2 = await Wallet.import_entity('0x0000000000000000000000000000000000000000000000000000000000000002');
+        await fullWallet2.save();
+
+        localStorage = await StorageCredential.generate_entity({
+            title: 'local',
+            driver_type: 'local',
+        });
+        await localStorage.save();
+
+        await buildSchemaValidators();
+
+    });
+
+    beforeEach(async () => {
+        mockDate(DATE_1);
+
+        const result: any = await CallRPCMethod(RPCShipChainVault.Create, {
+            storageCredentials: localStorage.id,
+            vaultWallet: fullWallet1.id,
+            additionalWallet: fullWallet2.id,
+            primitives: ["Telemetry"],
+        });
+        vaultId = result.vault_id;
+    });
+
+    afterEach(async () => {
+        resetDate();
+    });
+
+
+    afterAll(async() => {
+        await cleanupEntities(typeorm);
+    });
+
+    describe('Get', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCTelemetry.Get, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCTelemetry.Get, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCTelemetry.Get, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: vaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Shipper exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCTelemetry.Get, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: vaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCTelemetry.Get, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Gets empty Telemetry data`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCTelemetry.Get, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: vaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.vault_id).toEqual(vaultId);
+                expect(result.wallet_id).toEqual(fullWallet1.id);
+                expect(result.contents).toEqual([]);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('Add', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCTelemetry.Add, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'payload']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCTelemetry.Add, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCTelemetry.Add, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: vaultId,
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Shipper exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCTelemetry.Add, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: vaultId,
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCTelemetry.Add, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Validates payload is an object`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCTelemetry.Add, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: vaultId,
+                    payload: 'payload',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expectInvalidObjectParams(err, ['payload']);
+            }
+        }));
+
+        it(`Adds Telemetry data`, mochaAsync(async () => {
+            try {
+                let result: any = await CallRPCMethod(RPCTelemetry.Add, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: vaultId,
+                    payload: getPrimitiveData('Telemetry')[0],
+                });
+
+                expect(result.success).toBeTruthy();
+
+                let response: any = await CallRPCMethod(RPCTelemetry.Get, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: vaultId,
+                });
+                expect(response.success).toBeTruthy();
+                expect(response.vault_id).toEqual(vaultId);
+                expect(response.wallet_id).toEqual(fullWallet1.id);
+                expect(response).toBeDefined();
+                expect(response.contents).toEqual([getPrimitiveData('Telemetry')[0]]);
+
+                result = await CallRPCMethod(RPCTelemetry.Add, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: vaultId,
+                    payload: getPrimitiveData('Telemetry')[0],
+                });
+
+                expect(result.success).toBeTruthy();
+
+                response = await CallRPCMethod(RPCTelemetry.Get, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: vaultId,
+                });
+                expect(response.success).toBeTruthy();
+                expect(response.vault_id).toEqual(vaultId);
+                expect(response.wallet_id).toEqual(fullWallet1.id);
+                expect(response).toBeDefined();
+                expect(response.contents).toEqual([getPrimitiveData('Telemetry')[0], getPrimitiveData('Telemetry')[0]]);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+};

--- a/rpc/__tests__/primitives/utils.ts
+++ b/rpc/__tests__/primitives/utils.ts
@@ -51,7 +51,11 @@ const productResponseData = {
 };
 
 const trackingResponseData = [{
-    "one": 1
+    "tracking_one": 1
+}];
+
+const telemetryResponseData = [{
+    "telemetry_one": 1
 }];
 
 const itemResponseData = {
@@ -103,6 +107,8 @@ export function getPrimitiveData(linkedPrimitive: string): any {
             return productResponseData;
         case 'Tracking':
             return trackingResponseData;
+        case 'Telemetry':
+            return telemetryResponseData;
         case 'Item':
             return itemResponseData;
         case 'Shipment':

--- a/rpc/__tests__/primitives/utils.ts
+++ b/rpc/__tests__/primitives/utils.ts
@@ -131,7 +131,7 @@ function getNockedResponse(linkedPrimitive: string): any {
 
     nockedResponse.result = getPrimitiveData(linkedPrimitive);
 
-    if (linkedPrimitive !== 'Tracking') {
+    if (linkedPrimitive !== 'Tracking' && linkedPrimitive !== 'Telemetry') {
         nockedResponse.result = JSON.stringify(nockedResponse.result);
     }
 

--- a/rpc/__tests__/vault.ts
+++ b/rpc/__tests__/vault.ts
@@ -1541,6 +1541,227 @@ export const RPCVaultTests = async function() {
         }));
     });
 
+    describe('AddTelemetryData', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.AddTelemetryData, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault', 'payload']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.AddTelemetryData, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddTelemetryData, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                    payload: {},
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Validates Payload is object`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.AddTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: 'a string',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`Invalid Object: 'payload'`);
+            }
+
+            try {
+                await CallRPCMethod(RPCVault.AddTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: [],
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`Invalid Object: 'payload'`);
+            }
+        }));
+
+        it(`Adds new data`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.AddTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: {
+                        some: 'data'
+                    },
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.vault_signed).toBeDefined();
+                expect(result.vault_revision).toEqual(6);
+                expect(fs.existsSync(`./${testableLocalVaultId}/telemetry/20180101.json`)).toBeTruthy();
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('GetTelemetryData', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetTelemetryData, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetTelemetryData, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetTelemetryData, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Returns empty array when no telemetry data exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.GetTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: emptyLocalVaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.contents).toEqual([]);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Returns correct telemetry data when exists`, mochaAsync(async () => {
+            try {
+                const result: any = await CallRPCMethod(RPCVault.GetTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.contents).toEqual([{
+                    some: 'data'
+                }]);
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
     describe('VerifyVault', function() {
         it(`Has required parameters`, mochaAsync(async () => {
             let caughtError;
@@ -1885,7 +2106,7 @@ export const RPCVaultTests = async function() {
                     storageCredentials: localStorage.id,
                     vaultWallet: fullWallet1.id,
                     vault: testableLocalVaultId,
-                    sequence: 6,
+                    sequence: 7,
                 });
                 expect(result.success).toBeTruthy();
                 expect(result.historical_data).toEqual({
@@ -2179,6 +2400,296 @@ export const RPCVaultTests = async function() {
                 expect(result.success).toBeTruthy();
                 expect(result.historical_data).toEqual({
                     tracking: [{
+                        'some': 'data',
+                    },{
+                        'more': 'data',
+                    }],
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+    });
+
+    describe('GetHistoricalTelemetryData', function() {
+        it(`Has required parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {});
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectMissingRequiredParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Requires date or sequence`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidParameterCombinationParams(caughtError, [['date', 'sequence']], [[]]);
+        }));
+
+        it(`Requires only date or sequence`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_1,
+                    sequence: 1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidParameterCombinationParams(caughtError, [['date', 'sequence']], [['date', 'sequence']]);
+        }));
+
+        it(`Validates UUID parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: '123',
+                    vaultWallet: '123',
+                    vault: '123',
+                    date: DATE_1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidUUIDParams(caughtError, ['storageCredentials', 'vaultWallet', 'vault']);
+        }));
+
+        it(`Validates Date parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: 'Jan 1st, 2018',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidDateParams(caughtError, ['date']);
+        }));
+
+        it(`Validates Number parameters`, mochaAsync(async () => {
+            let caughtError;
+
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 'not a number',
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                caughtError = err;
+            }
+
+            expectInvalidNumberParams(caughtError, ['sequence']);
+        }));
+
+        it(`Validates StorageCredentials exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: uuidv4(),
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('StorageCredentials not found');
+            }
+        }));
+
+        it(`Validates Vault Wallet exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: uuidv4(),
+                    vault: testableLocalVaultId,
+                    date: DATE_1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain('Wallet not found');
+            }
+        }));
+
+        it(`Validates Vault exists`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: uuidv4(),
+                    date: DATE_1,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`Unable to load vault from Storage driver 'File Not Found'`);
+            }
+        }));
+
+        it(`Throws when no data exists for date`, mochaAsync(async () => {
+            try {
+                await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: emptyLocalVaultId,
+                    date: DATE_0,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`No data found for date`);
+            }
+        }));
+
+        it(`Returns latest data when exists`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_2,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    on_date: DATE_1,
+                    telemetry: [{
+                        some: 'data'
+                    }],
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Returns intermediate data when exists`, mochaAsync(async () => {
+            try {
+                // Add new data at DATE_3
+                mockDate(DATE_3);
+                await CallRPCMethod(RPCVault.AddTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    payload: {
+                        more: 'data',
+                    },
+                });
+                resetDate(); // <-- Very important!
+
+                // Check data at DATE_2 is still previous data
+                let result: any = await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_2,
+                });
+
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    on_date: DATE_1,
+                    telemetry: [{
+                        some: 'data'
+                    }],
+                });
+
+                // Check data at DATE_4 is most recent
+                result = await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    date: DATE_4,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    on_date: DATE_3,
+                    telemetry: [{
+                        some: 'data',
+                    },{
+                        more: 'data'
+                    }],
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Throws when no data exists for sequence`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 0,
+                });
+                fail("Did not Throw"); return;
+            } catch (err) {
+                expect(err.message).toContain(`No data found at specific sequence`);
+            }
+        }));
+
+        it(`Returns Telemetry data up to a sequence 2`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 6,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    telemetry: [{
+                        'some': 'data',
+                    }],
+                });
+            } catch (err) {
+                fail(`Should not have thrown [${err}]`);
+            }
+        }));
+
+        it(`Returns Telemetry data up to a sequence 3`, mochaAsync(async () => {
+            try {
+                resetDate(); // <-- Very important!
+                const result: any = await CallRPCMethod(RPCVault.GetHistoricalTelemetryData, {
+                    storageCredentials: localStorage.id,
+                    vaultWallet: fullWallet1.id,
+                    vault: testableLocalVaultId,
+                    sequence: 10,
+                });
+                expect(result.success).toBeTruthy();
+                expect(result.historical_data).toEqual({
+                    telemetry: [{
                         'some': 'data',
                     },{
                         'more': 'data',

--- a/rpc/primitives/telemetry.ts
+++ b/rpc/primitives/telemetry.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Wallet } from '../../src/entity/Wallet';
+import { StorageCredential } from '../../src/entity/StorageCredential';
+
+import { RPCMethod, RPCNamespace } from '../decorators';
+import { ShipChainVault } from '../../src/shipchain/vaults/ShipChainVault';
+import { PrimitiveType } from '../../src/shipchain/vaults/PrimitiveType';
+import { Telemetry } from '../../src/shipchain/vaults/primitives/Telemetry';
+
+@RPCNamespace({ name: 'Telemetry' })
+export class RPCTelemetry {
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+        },
+    })
+    public static async Get(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const vault = new ShipChainVault(storage, args.vault);
+        await vault.loadMetadata();
+
+        const primitive: Telemetry = await vault.getPrimitive(PrimitiveType.Telemetry.name);
+
+        const content: any = await primitive.getTelemetry(wallet);
+
+        return {
+            success: true,
+            wallet_id: wallet.id,
+            vault_id: args.vault,
+            contents: content,
+        };
+    }
+
+    @RPCMethod({
+        require: ['storageCredentials', 'vaultWallet', 'vault', 'payload'],
+        validate: {
+            uuid: ['storageCredentials', 'vaultWallet', 'vault'],
+            object: ['payload'],
+        },
+    })
+    public static async Add(args) {
+        const storage = await StorageCredential.getOptionsById(args.storageCredentials);
+        const wallet = await Wallet.getById(args.vaultWallet);
+
+        const vault = new ShipChainVault(storage, args.vault);
+        await vault.loadMetadata();
+
+        const primitive: Telemetry = await vault.getPrimitive(PrimitiveType.Telemetry.name);
+        await primitive.addTelemetry(wallet, args.payload);
+
+        const vaultWriteResponse = await vault.writeMetadata(wallet);
+
+        return {
+            ...vaultWriteResponse,
+            success: true,
+        };
+    }
+}

--- a/src/shipchain/LoadVault.ts
+++ b/src/shipchain/LoadVault.ts
@@ -21,6 +21,7 @@ export class LoadVault extends Vault {
     private static readonly TRACKING: string = 'tracking';
     private static readonly SHIPMENT: string = 'shipment';
     private static readonly DOCUMENTS: string = 'documents';
+    private static readonly TELEMETRY: string = 'telemetry';
 
     constructor(storage_driver, id?) {
         super(storage_driver, id);
@@ -31,6 +32,7 @@ export class LoadVault extends Vault {
         this.getOrCreateContainer(author, LoadVault.TRACKING, 'external_list_daily');
         this.getOrCreateContainer(author, LoadVault.SHIPMENT, 'embedded_file');
         this.getOrCreateContainer(author, LoadVault.DOCUMENTS, 'external_file_multi');
+        this.getOrCreateContainer(author, LoadVault.TELEMETRY, 'external_list_daily');
         return this.meta;
     }
 
@@ -70,6 +72,16 @@ export class LoadVault extends Vault {
         return await this.containers[LoadVault.DOCUMENTS].listFiles();
     }
 
+    async addTelemetryData(author: Wallet, payload) {
+        await this.loadMetadata();
+        await this.containers[LoadVault.TELEMETRY].append(author, payload);
+    }
+
+    async getTelemetryData(author: Wallet) {
+        await this.loadMetadata();
+        return await this.containers[LoadVault.TELEMETRY].decryptContents(author);
+    }
+
     // Historical Retrievals
     // =====================
 
@@ -90,6 +102,11 @@ export class LoadVault extends Vault {
         return await this.getHistoricalDataByDate(author, LoadVault.DOCUMENTS, date, documentName);
     }
 
+    async getHistoricalTelemetryByDate(author: Wallet, date: string) {
+        await this.loadMetadata();
+        return await this.getHistoricalDataByDate(author, LoadVault.TELEMETRY, date);
+    }
+
     async getHistoricalShipmentBySequence(author: Wallet, sequence: number) {
         await this.loadMetadata();
         const contents = await this.getHistoricalDataBySequence(author, LoadVault.SHIPMENT, sequence);
@@ -105,5 +122,10 @@ export class LoadVault extends Vault {
     async getHistoricalDocumentBySequence(author: Wallet, sequence: number, documentName: string) {
         await this.loadMetadata();
         return await this.getHistoricalDataBySequence(author, LoadVault.DOCUMENTS, sequence, documentName);
+    }
+
+    async getHistoricalTelemetryBySequence(author: Wallet, sequence: number) {
+        await this.loadMetadata();
+        return await this.getHistoricalDataBySequence(author, LoadVault.TELEMETRY, sequence);
     }
 }

--- a/src/shipchain/__tests__/loadvault.ts
+++ b/src/shipchain/__tests__/loadvault.ts
@@ -123,6 +123,32 @@ export const LoadVaultTests = async function() {
         expect(testTracking).toEqual([TRACKING_01, TRACKING_02]);
     });
 
+    it('can add and retrieve Telemetry data', async() => {
+        let author: Wallet = await Wallet.generate_entity();
+
+        /* New vault shouldn't exist yet */
+        let vault = new LoadVault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+
+        // Test with a single point
+        await vault.addTelemetryData(author, TELEMETRY_01);
+        await vault.writeMetadata(author);
+
+        vault = new LoadVault(storage_driver, vault.id);
+        let testTelemetry = await vault.getTelemetryData(author);
+
+        expect(testTelemetry).toEqual([TELEMETRY_01]);
+
+        // Test with another point
+        await vault.addTelemetryData(author, TELEMETRY_02);
+        await vault.writeMetadata(author);
+
+        vault = new LoadVault(storage_driver, vault.id);
+        testTelemetry = await vault.getTelemetryData(author);
+
+        expect(testTelemetry).toEqual([TELEMETRY_01, TELEMETRY_02]);
+    });
+
     it('can add and retrieve Documents', async() => {
         let author: Wallet = await Wallet.generate_entity();
 
@@ -171,6 +197,9 @@ const SHIPMENT_02 = {
 
 const TRACKING_01 = {tracking: 1};
 const TRACKING_02 = {tracking: 2};
+
+const TELEMETRY_01 = {telemetry: 1};
+const TELEMETRY_02 = {telemetry: 2};
 
 const DOCUMENT_01 = {
     name: 'file01.txt',

--- a/src/shipchain/__tests__/telemetry.ts
+++ b/src/shipchain/__tests__/telemetry.ts
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+
+
+require('../../__tests__/testLoggingConfig');
+
+import 'mocha';
+import { ShipChainVault } from '../vaults/ShipChainVault';
+import { Telemetry } from "../vaults/primitives/Telemetry";
+import { Wallet } from '../../entity/Wallet';
+import { CloseConnection } from "../../redis";
+import { EncryptorContainer } from '../../entity/encryption/EncryptorContainer';
+
+const storage_driver = { driver_type: 'local', base_path: 'storage/vault-tests' };
+
+
+export const TelemetryPrimitiveTests = async function() {
+    let author: Wallet;
+    let vault: ShipChainVault;
+
+    beforeAll(async () => {
+        await EncryptorContainer.init();
+        author = await Wallet.generate_entity();
+    });
+
+    beforeEach(async() => {
+        vault = new ShipChainVault(storage_driver);
+        await vault.getOrCreateMetadata(author);
+    });
+
+    afterEach(async() => {
+        await vault.deleteEverything();
+    });
+
+    afterAll(async () => {
+        CloseConnection();
+    });
+
+    let refreshPrimitive = async(): Promise<Telemetry> => {
+        await vault.writeMetadata(author);
+        await vault.loadMetadata();
+        return vault.getPrimitive('Telemetry');
+    };
+
+    let injectPrimitive = async (): Promise<Telemetry> => {
+        vault.injectPrimitive('Telemetry');
+        return await refreshPrimitive();
+    };
+
+    it(`can be created`, async () => {
+        let telemetry = new Telemetry(vault);
+
+        expect(telemetry.name).toEqual('Telemetry');
+        expect(telemetry.container_type).toEqual('external_list_daily');
+        expect(telemetry.meta.isPrimitive).toBeTruthy();
+    });
+
+    it(`is empty on creation`, async () => {
+        let telemetry = new Telemetry(vault);
+
+        let telemetryData = await telemetry.getTelemetry(author);
+
+        expect(telemetryData).toEqual([]);
+    });
+
+    it(`can set one value`, async () => {
+        let telemetry = await injectPrimitive();
+
+        await telemetry.addTelemetry(author, {
+            "one": 1,
+        });
+
+        telemetry = await refreshPrimitive();
+
+        let telemetryData = await telemetry.getTelemetry(author);
+        expect(telemetryData.length).toEqual(1);
+        expect(telemetryData[0]).toEqual({
+            "one": 1,
+        });
+    });
+
+    it(`can append multiple values`, async () => {
+        let telemetry = await injectPrimitive();
+
+        await telemetry.addTelemetry(author, {
+            "one": 1,
+        });
+        await telemetry.addTelemetry(author, {
+            "two": 2,
+        });
+
+        telemetry = await refreshPrimitive();
+
+        let telemetryData = await telemetry.getTelemetry(author);
+        expect(telemetryData.length).toEqual(2);
+        expect(telemetryData[0]).toEqual({
+            "one": 1,
+        });
+        expect(telemetryData[1]).toEqual({
+            "two": 2,
+        });
+    });
+
+};

--- a/src/shipchain/__tests__/utils.ts
+++ b/src/shipchain/__tests__/utils.ts
@@ -51,7 +51,11 @@ const productResponseData = {
 };
 
 const trackingResponseData = [{
-    "one": 1
+    "tracking_one": 1
+}];
+
+const telemetryResponseData = [{
+    "telemetry_one": 1
 }];
 
 const itemResponseData = {
@@ -103,6 +107,8 @@ export function getPrimitiveData(linkedPrimitive: string): any {
             return productResponseData;
         case 'Tracking':
             return trackingResponseData;
+        case 'Telemetry':
+            return telemetryResponseData;
         case 'Item':
             return itemResponseData;
         case 'Shipment':
@@ -125,7 +131,7 @@ function getNockedResponse(linkedPrimitive: string): any {
 
     nockedResponse.result = getPrimitiveData(linkedPrimitive);
 
-    if (linkedPrimitive !== 'Tracking') {
+    if (linkedPrimitive !== 'Tracking' && linkedPrimitive !== 'Telemetry') {
         nockedResponse.result = JSON.stringify(nockedResponse.result);
     }
 

--- a/src/shipchain/vaults/PrimitiveType.ts
+++ b/src/shipchain/vaults/PrimitiveType.ts
@@ -20,6 +20,7 @@ import { ShipChainVault } from './ShipChainVault';
 import { Procurement } from './primitives/Procurement';
 import { Shipment } from './primitives/Shipment';
 import { Tracking } from './primitives/Tracking';
+import { Telemetry } from './primitives/Telemetry';
 import { Document } from './primitives/Document';
 import { Product } from './primitives/Product';
 import { Item } from './primitives/Item';
@@ -33,6 +34,7 @@ export class PrimitiveType {
     static readonly Procurement = new PrimitiveType('Procurement', Procurement);
     static readonly Shipment = new PrimitiveType('Shipment', Shipment);
     static readonly Tracking = new PrimitiveType('Tracking', Tracking);
+    static readonly Telemetry = new PrimitiveType('Telemetry', Telemetry);
     static readonly Document = new PrimitiveType('Document', Document);
     static readonly Product = new PrimitiveType('Product', Product);
     static readonly Item = new PrimitiveType('Item', Item);

--- a/src/shipchain/vaults/primitives/Shipment.ts
+++ b/src/shipchain/vaults/primitives/Shipment.ts
@@ -51,6 +51,7 @@ export class ShipmentProperties extends PrimitiveProperties {
     fields: {};
     documents: {};
     tracking: string;
+    telemetry: string;
     items: {};
 
     constructor(initializingJson: any = {}) {
@@ -60,6 +61,7 @@ export class ShipmentProperties extends PrimitiveProperties {
         primitive.fields = {};
         primitive.documents = {};
         primitive.tracking = null;
+        primitive.telemetry = null;
         primitive.items = {};
     }
 
@@ -156,6 +158,24 @@ export class Shipment extends EmbeddedFileContainer implements Primitive {
         Primitive.validateLinkedPrimitive(trackingLink, PrimitiveType.Tracking.name);
         let shipment: ShipmentProperties = await this.getPrimitiveProperties(ShipmentProperties, wallet);
         shipment.tracking = trackingLink;
+        await this.setContents(wallet, JSON.stringify(shipment));
+    }
+
+    // TELEMETRY ACCESS
+    // ===============
+    async getTelemetry(wallet: Wallet): Promise<any> {
+        let shipment: ShipmentProperties = await this.getPrimitiveProperties(ShipmentProperties, wallet);
+        if (shipment && shipment.telemetry) {
+            return await RemoteVault.processContentForLinks(shipment.telemetry);
+        } else {
+            throw new Error(`Telemetry not found in Shipment`);
+        }
+    }
+
+    async setTelemetry(wallet: Wallet, telemetryLink: string): Promise<any> {
+        Primitive.validateLinkedPrimitive(telemetryLink, PrimitiveType.Telemetry.name);
+        let shipment: ShipmentProperties = await this.getPrimitiveProperties(ShipmentProperties, wallet);
+        shipment.telemetry = telemetryLink;
         await this.setContents(wallet, JSON.stringify(shipment));
     }
 

--- a/src/shipchain/vaults/primitives/Telemetry.ts
+++ b/src/shipchain/vaults/primitives/Telemetry.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2019 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Primitive, PrimitiveProperties } from '../Primitive';
+import { PrimitiveType } from '../PrimitiveType';
+import { ShipChainVault } from '../ShipChainVault';
+
+import { applyMixins } from '../../../utils';
+
+import { Wallet } from '../../../entity/Wallet';
+import { ExternalListDailyContainer } from '../../../vaults/containers/ExternalDirectoryContainer';
+
+export class Telemetry extends ExternalListDailyContainer implements Primitive {
+    constructor(vault: ShipChainVault, meta?: any) {
+        super(vault, PrimitiveType.Telemetry.name, meta);
+        this.injectContainerMetadata();
+    }
+
+    // TELEMETRY ACCESS
+    // ===============
+    async getTelemetry(wallet: Wallet): Promise<any> {
+        return await this.decryptContents(wallet);
+    }
+
+    async addTelemetry(wallet: Wallet, tracking: any): Promise<void> {
+        await this.append(wallet, tracking);
+    }
+
+    // Primitive Mixin placeholders
+    // ----------------------------
+    /* istanbul ignore next */
+    injectContainerMetadata(): void {}
+    /* istanbul ignore next */
+    async getPrimitiveProperties<T extends PrimitiveProperties>(
+        klass: new (...args: any[]) => T,
+        wallet: Wallet,
+    ): Promise<T> {
+        return;
+    }
+}
+
+applyMixins(Telemetry, [Primitive]);


### PR DESCRIPTION
The predefined Engine vaults need a place to store generic sensor data.

The LoadVault has a new container `telemetry` added that mimics the existing tracking container.

A new Telemetry primitive has been created which is an append-only list of sensor data.  The Shipment primitive contains a link to a Telemetry primitive similar to the existing Tracking primitive.

- RPC endpoints have been included for LoadVault, Telemetry Primitive, and Shipment linked Telemetry data.  
- Unit tests included.
- Documentation udpated.
-  Postman collection updated.