### PR TITLE
Shipment location contact fields

### DIFF
--- a/ingestPrimitives.js
+++ b/ingestPrimitives.js
@@ -20,7 +20,7 @@ const request = require("request");
 
 // Setup the source URL for the Primitive JSONSchema
 const schemaBaseUrl = "http://schema.shipchain.io/";
-const schemaVersion = "1.2.2";
+const schemaVersion = "1.2.3";
 const schemas = [
   "shipment"
 ];

--- a/rpc/primitives/schema/shipment.json
+++ b/rpc/primitives/schema/shipment.json
@@ -84,22 +84,22 @@
       "maxLength": 255
     },
     "ship_from_location": {
-      "$ref": "http://schema.shipchain.io/1.2.2/location.json",
+      "$ref": "http://schema.shipchain.io/1.2.3/location.json",
       "title": "Ship from address",
       "description": "The Shipment's ship-from address"
     },
     "ship_to_location": {
-      "$ref": "http://schema.shipchain.io/1.2.2/location.json",
+      "$ref": "http://schema.shipchain.io/1.2.3/location.json",
       "title": "Ship to address",
       "description": "The Shipment's ship-to address"
     },
     "final_destination_location": {
-      "$ref": "http://schema.shipchain.io/1.2.2/location.json",
+      "$ref": "http://schema.shipchain.io/1.2.3/location.json",
       "title": "Shipment final destination",
       "description": "The Shipment's Final Destination address"
     },
     "bill_to_location": {
-      "$ref": "http://schema.shipchain.io/1.2.2/location.json",
+      "$ref": "http://schema.shipchain.io/1.2.3/location.json",
       "title": "Shipment's billed location (if different from ship_to_location)",
       "description": "The Shipment's Bill To address"
     },


### PR DESCRIPTION
This `PR` pins shipchain's schema version 1.2.3 still to be released with this PR:
https://github.com/ShipChain/schema/pull/11
which adds contacts fields to location object.