### PR TITLE
Address CVE-2019-19919

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "ts-jest": "^23.10.5"
   },
   "resolutions": {
-    "handlebars": "4.1.2",
+    "handlebars": "4.3.0",
     "js-yaml": "3.13.1"
   },
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2471,10 +2471,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@4.1.2, handlebars@^4.0.3:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@4.3.0, handlebars@^4.0.3:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.3.0.tgz#427391b584626c9c9c6ffb7d1fb90aa9789221cc"
+  integrity sha512-7XlnO8yBXOdi7AzowjZssQr47Ctidqm7GbgARapOaqSN9HQhlClnOkR9HieGauIT3A8MBC6u9wPCXs97PCYpWg==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
According to https://github.com/advisories/GHSA-w457-6q6x-cgp9 handlebars should be updated to >=4.3.0. Since it was hard-pinned to 4.1.2 before, and I don't know the reasoning behind that, I hard pinned to the earliest-possible version (4.3.0 instead of ^4.3.0).