### PR TITLE
Hotfix: Missed wallet mapping

### DIFF
--- a/jest.testOrder.ts
+++ b/jest.testOrder.ts
@@ -62,6 +62,7 @@ import { WalletEntityTests } from './src/__tests__/wallets';
 import { GasPriceOracleTests } from "./src/__tests__/gaspriceoracle";
 import { EventSubscriptionPostsTests } from "./src/__tests__/eventSubscriptionPosts";
 import { UtilsTests } from "./src/__tests__/utils";
+import { RedisTests } from "./src/__tests__/redis";
 
 
 // ShipChain Tests
@@ -179,6 +180,7 @@ describe('Core', async () => {
     describe('GasPriceOracle', GasPriceOracleTests);
     describe('EventSubscriptionPosts', EventSubscriptionPostsTests);
     describe('Utils', UtilsTests);
+    describe('Redis', RedisTests);
 
 });
 

--- a/src/__tests__/contracts.ts
+++ b/src/__tests__/contracts.ts
@@ -50,7 +50,9 @@ export const ContractEntityTests = async function() {
         async () => {
             await Project.loadFixturesFromFile('/app/src/__tests__/meta.json');
             const owner = await Wallet.generate_entity();
+            await owner.save();
             const other = await Wallet.generate_entity();
+            await other.save();
 
             const local = await utils.setupLocalTestNetContracts({ ShipToken: LATEST_SHIPTOKEN, LOAD: LATEST_LOAD, NOTARY: LATEST_NOTARY }, [owner]);
             const network: Network = await Network.getLocalTestNet();

--- a/src/__tests__/eventsubscriptions.ts
+++ b/src/__tests__/eventsubscriptions.ts
@@ -82,7 +82,9 @@ export const EventSubscriptionEntityTests = async  function() {
             }
             await Project.loadFixturesFromFile('/app/src/__tests__/meta.json');
             const owner = await Wallet.generate_entity();
+            await owner.save();
             const other = await Wallet.generate_entity();
+            await other.save();
 
             const local = await utils.setupLocalTestNetContracts({ShipToken: LATEST_SHIPTOKEN, LOAD: LATEST_LOAD}, [owner]);
             const network: Network = await Network.getLocalTestNet();

--- a/src/__tests__/redis.ts
+++ b/src/__tests__/redis.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 ShipChain, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+require('./testLoggingConfig');
+
+import 'mocha';
+import { cacheGet, cacheSet } from "../redis";
+
+export const RedisTests = async function() {
+    const missingKey = 'missing_key';
+    const missingField = 'missing_field';
+
+    const key = 'new_key';
+    const field = 'new_field';
+    const value = 'new_value';
+    const value2 = 'new_value2';
+
+    it(`get missing key should be null`, async() => {
+        const noValue = await cacheGet(missingKey, missingField);
+        expect(noValue).toBeNull();
+    });
+
+    it(`get missing field should be null`, async() => {
+        try {
+            await cacheSet(key, field, value);
+        } catch (err) {
+            fail(`Should not have thrown [${err}]`);
+        }
+
+        const noValue = await cacheGet(key, missingField);
+        expect(noValue).toBeNull();
+    });
+
+    it(`set new key should succeed`, async() => {
+        try {
+            await cacheSet(key, field, value);
+        } catch (err) {
+            fail(`Should not have thrown [${err}]`);
+        }
+
+        const returnedValue = await cacheGet(key, field);
+        expect(returnedValue).toEqual(value);
+    });
+
+    it(`overwrite existing key should succeed`, async() => {
+        try {
+            await cacheSet(key, field, value);
+        } catch (err) {
+            fail(`Should not have thrown [${err}]`);
+        }
+
+        let returnedValue = await cacheGet(key, field);
+        expect(returnedValue).toEqual(value);
+
+        try {
+            await cacheSet(key, field, value2);
+        } catch (err) {
+            fail(`Should not have thrown [${err}]`);
+        }
+
+        returnedValue = await cacheGet(key, field);
+        expect(returnedValue).toEqual(value2);
+    });
+
+};

--- a/src/__tests__/redis.ts
+++ b/src/__tests__/redis.ts
@@ -75,4 +75,69 @@ export const RedisTests = async function() {
         expect(returnedValue).toEqual(value2);
     });
 
+    it(`cacheSet should throw on undefined key`, async() => {
+        let caughtError;
+
+        try {
+            await cacheSet(undefined, field, value);
+            fail(`Should have thrown`);
+        } catch (err) {
+            caughtError = err;
+        }
+
+        expect(caughtError.toString()).toContain(`Invalid parameters for cacheSet: (undefined,${field},${value})`);
+    });
+
+    it(`cacheSet should throw on undefined field`, async() => {
+        let caughtError;
+
+        try {
+            await cacheSet(key, undefined, value);
+            fail(`Should have thrown`);
+        } catch (err) {
+            caughtError = err;
+        }
+
+        expect(caughtError.toString()).toContain(`Invalid parameters for cacheSet: (${key},undefined,${value})`);
+    });
+
+    it(`cacheSet should throw on undefined value`, async() => {
+        let caughtError;
+
+        try {
+            await cacheSet(key, field, undefined);
+            fail(`Should have thrown`);
+        } catch (err) {
+            caughtError = err;
+        }
+
+        expect(caughtError.toString()).toContain(`Invalid parameters for cacheSet: (${key},${field},undefined)`);
+    });
+
+    it(`cacheGet should throw on undefined key`, async() => {
+        let caughtError;
+
+        try {
+            await cacheGet(undefined, field);
+            fail(`Should have thrown`);
+        } catch (err) {
+            caughtError = err;
+        }
+
+        expect(caughtError.toString()).toContain(`Invalid parameters for cacheGet: (undefined,${field})`);
+    });
+
+    it(`cacheGet should throw on undefined field`, async() => {
+        let caughtError;
+
+        try {
+            await cacheGet(key, undefined);
+            fail(`Should have thrown`);
+        } catch (err) {
+            caughtError = err;
+        }
+
+        expect(caughtError.toString()).toContain(`Invalid parameters for cacheGet: (${key},undefined)`);
+    });
+
 };

--- a/src/entity/Wallet.ts
+++ b/src/entity/Wallet.ts
@@ -37,7 +37,7 @@ export class Wallet extends BaseEntity {
     private unlocked_private_key: string;
 
     get asyncEvmAddress(): Promise<string> {
-        // TODO: Potential local caching opportunity here
+        // TODO: cache mapped addresses in redis
         return (async () => {
             if (LoomHooks.enabled) {
                 return await LoomHooks.getOrCreateMapping(
@@ -60,6 +60,9 @@ export class Wallet extends BaseEntity {
 
         wallet.unlocked_private_key = await EncryptorContainer.defaultEncryptor.decrypt(wallet.private_key);
 
+        // Ensure wallet mapping is properly initialized if required
+        await wallet.asyncEvmAddress;
+
         return wallet;
     }
 
@@ -74,6 +77,9 @@ export class Wallet extends BaseEntity {
         }
 
         wallet.unlocked_private_key = await EncryptorContainer.defaultEncryptor.decrypt(wallet.private_key);
+
+        // Ensure wallet mapping is properly initialized if required
+        await wallet.asyncEvmAddress;
 
         return wallet;
     }

--- a/src/eth/LoomHooks.ts
+++ b/src/eth/LoomHooks.ts
@@ -98,9 +98,7 @@ export class LoomHooks {
             const loomAddress = new Address(loomClient.chainId, LocalAddress.fromPublicKey(loomPublicKey));
             const mapper = await AddressMapper.createAsync(loomClient, loomAddress);
             await mapper.addIdentityMappingAsync(ethLoomAddress, loomAddress, loomEthSigner);
-            logger.debug(
-                `Added loom mapping for ${loomAddress.local.toString()} -> ${ethLoomAddress.local.toString()}`,
-            );
+            logger.info(`Added loom mapping for ${loomAddress.local.toString()} -> ${ethLoomAddress.local.toString()}`);
             return loomAddress.local.toString();
         } catch (err) {
             let errorToThrow = err;
@@ -110,7 +108,7 @@ export class LoomHooks {
                 try {
                     const mapper = await AddressMapper.createAsync(loomClient, ethLoomAddress);
                     const mapping = await mapper.getMappingAsync(ethLoomAddress);
-                    logger.silly(
+                    logger.debug(
                         `Existing loom mapping for ${mapping.to.local.toString()} -> ${ethLoomAddress.local.toString()}`,
                     );
                     return mapping.to.local.toString();

--- a/src/redis.ts
+++ b/src/redis.ts
@@ -47,7 +47,12 @@ export function getRedisClient() {
 }
 
 export async function cacheGet(key: string, field: string): Promise<any> {
+    if (!key || !field) {
+        throw new Error(`Invalid parameters for cacheGet: (${key},${field})`);
+    }
+
     const client = getRedisClient();
+
     try {
         return await client.asyncHashGet(key, field);
     } catch (err) {
@@ -57,7 +62,12 @@ export async function cacheGet(key: string, field: string): Promise<any> {
 }
 
 export async function cacheSet(key: string, field: string, value: any): Promise<void> {
+    if (!key || !field || !value) {
+        throw new Error(`Invalid parameters for cacheSet: (${key},${field},${value})`);
+    }
+
     const client = getRedisClient();
+
     try {
         await client.asyncHashSet(key, field, value);
     } catch (err) {


### PR DESCRIPTION
Wallets that existed in the database prior to the switch to the sidechain candidate in DEV were sometimes failing to build transactions against the sidechain.  This was due to a case where the wallet was not properly retrieved prior to the attempt to generate the next nonce.  The sidechain was unaware of the wallet and returned an unexpected error.  This patch resolves that issue by ensuring the wallet mapping has been performed in more scenarios.

However, this update decreased performance anywhere a wallet was accessed due to extra round trip requests to the sidechain to query the AddressMapper contract.  The outstanding "TODO" for caching the evm address was implemented here to mitigate the performance impact.  New caching methods were introduced (`cacheSet` and `cacheGet`) that are currently in-use in the Wallet entity for caching the ethereum address to the mapped address on the sidechain.