### PR TITLE
Hotfix: correct transaction receipts in local development with geth-poa

### DIFF
--- a/src/eth/ethers/EthersEthereumService.ts
+++ b/src/eth/ethers/EthersEthereumService.ts
@@ -186,7 +186,7 @@ export class EthersEthereumService extends AbstractEthereumService {
                 logger.silly(`${tx.hash} waiting for ${this.transactionConfirmations} confirmations`);
                 let confirmation: any = tx;
 
-                if (this.transactionConfirmations > 1) {
+                if (this.transactionConfirmations >= 1) {
                     confirmation = await tx.wait(this.transactionConfirmations);
                 }
 


### PR DESCRIPTION
Receipts sent to Transmission were a copy of the transaction itself instead of the receipt.