### PR TITLE
Capture EVM hash in transaction receipt

### DIFF
--- a/src/eth/ethers/EthersEthereumService.ts
+++ b/src/eth/ethers/EthersEthereumService.ts
@@ -167,10 +167,9 @@ export class EthersEthereumService extends AbstractEthereumService {
             logger.debug(`Submitted Transaction ${tx.hash}`);
 
             // Wait for initial mine
-            await tx.wait();
+            const receipt = await tx.wait();
             logger.debug(`Transaction ${tx.hash} mined`);
 
-            const receipt = await this.provider.getTransactionReceipt(tx.hash);
             logger.silly(`receipt ${JSON.stringify(receipt, null, 2)}`);
 
             // Post-byzantium blocks will have a status (0 indicated failure during execution)

--- a/src/eth/ethers/LoomEthersEthereumService.ts
+++ b/src/eth/ethers/LoomEthersEthereumService.ts
@@ -49,7 +49,7 @@ class LoomTxProvider extends ethers.providers.JsonRpcProvider {
                 this._emitted['t:' + tx.hash] = 'pending';
             }
 
-            return this.waitForTransaction(tx.hash, confirmations).then((receipt) => {
+            return this.waitForTransaction(tx.hash, confirmations).then(async (receipt) => {
                 if (receipt == null && confirmations === 0) {
                     return null;
                 }
@@ -64,6 +64,11 @@ class LoomTxProvider extends ethers.providers.JsonRpcProvider {
                         transaction: tx,
                     });
                 }
+
+                // Capture the EVM Hash from the Loom Transaction
+                const evmTx = await this.getTransaction(tx.hash);
+                receipt['evmHash'] = evmTx.hash;
+
                 return receipt;
             });
         };


### PR DESCRIPTION
When working with ShipChain's sidechain, there are currently 3 different transaction hash values for a single transaction; each with their own use.  Engine has been able to process transactions while only tracking one of these hashes.  However, an additional hash is required in the transaction receipts to allow for reverse lookups from a node's `/eth` endpoint directly.